### PR TITLE
[IIIF 258] Update Maven enforcer to require JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
 jdk:
-- oraclejdk11
 - openjdk11
 
 install:
@@ -9,6 +8,11 @@ install:
 
 script:
 - mvn verify -Dbucketeer.s3.access_key="$AWS_ACCESS_KEY_ID" -Dbucketeer.s3.secret_key="$AWS_SECRET_ACCESS_KEY"
+
+# Cache Maven local repository to save time on builds
+cache:
+  directories:
+  - $HOME/.m2
 
 # We want all PRs built but only merges on master branch and tags under semantic version scheme
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
             tags: true
       if: (NOT type IN (pull_request)) AND (branch =~ /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/)
 
+
 notifications:
   email:
     recipients:

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,21 @@
       <!-- Enforcer enforces some basic characteristics of the project -->
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.11.0,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- Codacy runs automated code reviews and code analytics -->


### PR DESCRIPTION
@hardyoyo I'm only doing one of these. I'll leave the other to you. The issue you ran into was you didn't notice the enforcer was already defined in the POM so you created an additional one, causing Maven to complain about there being more than one there. It could have been a conflict with the one in the parent project, but in this case was just a conflict with one already in the current project.

I've tested by changing my local JDK to 8 and the build then does throw an error from the enforcer plugin.