### PR TITLE
Update README to reflect '/status'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can run a development instance of Bucketeer by typing the following within t
 
     mvn -Plive test
 
-Once run, the service can be verified/accessed at [http://localhost:8888/ping](http://localhost:8888/ping). The API documentation can be accessed at [http://localhost:8888/docs](http://localhost:8888/docs)
+Once run, the service can be verified/accessed at [http://localhost:8888/status](http://localhost:8888/status). The API documentation can be accessed at [http://localhost:8888/docs](http://localhost:8888/docs)
 
 ## Testing Considerations
 


### PR DESCRIPTION
Oops, I missed an update in the README (renaming /ping to /status). This PR fixes that.