### PR TITLE
[IIIF-386] Add batch job name to s3 upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
   <properties>
     <vertx.version>3.7.1</vertx.version>
+    <vertx.super.s3.version>1.1.0</vertx.super.s3.version>
     <slf4j.ext.version>1.7.26</slf4j.ext.version>
     <aws.sdk.version>1.11.478</aws.sdk.version>
     <opencsv.version>4.6</opencsv.version>
@@ -59,7 +60,6 @@
     <shade.plugin.version>2.4.3</shade.plugin.version>
     <vertx.plugin.version>1.0.18</vertx.plugin.version>
     <codacy.plugin.version>1.0.2</codacy.plugin.version>
-    <vertx.super.s3.version>1.0.0</vertx.super.s3.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>
 
     <!-- Whether auto-reloading should be turned on for the live test profile -->

--- a/src/main/java/edu/ucla/library/bucketeer/Constants.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Constants.java
@@ -19,17 +19,17 @@ public final class Constants {
     /**
      * The ID for the image that's going to be processed.
      */
-    public static final String IMAGE_ID = "imageId";
+    public static final String IMAGE_ID = "image-id";
 
     /**
      * The path to the TIFF file that's going to be read.
      */
-    public static final String FILE_PATH = "filePath";
+    public static final String FILE_PATH = "file-path";
 
     /**
      * The batch job name (i.e., the name of the file being processed)
      */
-    public static final String JOB_NAME = "jobName";
+    public static final String JOB_NAME = "job-name";
 
     /**
      * The success status for an individual image in a batch job.
@@ -39,7 +39,7 @@ public final class Constants {
     /**
      * The Slack handle of the person submitting the batch job
      */
-    public static final String SLACK_HANDLE = "slackHandle";
+    public static final String SLACK_HANDLE = "slack-handle";
 
     /**
      * The name of the "failures only" processing flag.
@@ -89,7 +89,7 @@ public final class Constants {
     /**
      * The name of the mapping of deployed verticles.
      */
-    public static final String VERTICLE_MAP = "bucketeer.verticles";
+    public static final String VERTICLE_MAP = "bucketeer-verticles";
 
     /**
      * Private constructor for Constants class.

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/ImageWorkerVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/ImageWorkerVerticle.java
@@ -6,8 +6,6 @@ import static edu.ucla.library.bucketeer.Constants.MESSAGES;
 import java.io.File;
 import java.io.IOException;
 
-import javax.naming.ConfigurationException;
-
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
@@ -24,7 +22,7 @@ public class ImageWorkerVerticle extends AbstractBucketeerVerticle {
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageWorkerVerticle.class, MESSAGES);
 
     @Override
-    public void start() throws ConfigurationException, IOException {
+    public void start() throws IOException {
         if (LOGGER.isDebugEnabled()) {
             final String className = ImageWorkerVerticle.class.getSimpleName();
             final String threadName = Thread.currentThread().getName();

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
@@ -5,9 +5,12 @@ import static edu.ucla.library.bucketeer.Constants.MESSAGES;
 
 import com.amazonaws.regions.RegionUtils;
 
+import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
 import info.freelibrary.vertx.s3.S3Client;
+import info.freelibrary.vertx.s3.UserMetadata;
 
 import edu.ucla.library.bucketeer.Config;
 import edu.ucla.library.bucketeer.Constants;
@@ -72,26 +75,34 @@ public class S3BucketVerticle extends AbstractBucketeerVerticle {
                 storageRequest.mergeIn(config);
             }
 
-            final String imageID = storageRequest.getString(Constants.IMAGE_ID);
             final String jpxPath = storageRequest.getString(Constants.FILE_PATH);
+            final String jobName = storageRequest.getString(Constants.JOB_NAME);
             final String s3Bucket = storageRequest.getString(Config.S3_BUCKET);
+            final String imageID = storageRequest.getString(Constants.IMAGE_ID);
+            final String imageIDSansExt = FileUtils.stripExt(imageID);
 
             LOGGER.debug(MessageCodes.BUCKETEER_010, imageID, jpxPath, s3Bucket);
 
             vertx.fileSystem().open(jpxPath, new OpenOptions().setRead(true), open -> {
                 if (open.succeeded()) {
                     final AsyncFile asyncFile = open.result();
+                    final UserMetadata metadata = new UserMetadata(Constants.IMAGE_ID, imageIDSansExt);
+
+                    // If there is a job name, supply it in user metadata on S3 upload
+                    if (StringUtils.trimToNull(jobName) != null) {
+                        metadata.add(Constants.JOB_NAME, jobName);
+                    }
 
                     LOGGER.debug(MessageCodes.BUCKETEER_044, imageID, jpxPath, s3Bucket);
 
                     // If our connection pool is full, drop back and try resubmitting the request
                     try {
-                        myS3Client.put(s3Bucket, imageID, asyncFile, response -> {
+                        myS3Client.put(s3Bucket, imageID, asyncFile, metadata, response -> {
                             final int statusCode = response.statusCode();
 
                             // If we get a successful upload response code, note this in our results map
                             if (statusCode == HTTP.OK) {
-                                vertx.sharedData().getLocalMap(Constants.RESULTS_MAP).put(imageID, true);
+                                vertx.sharedData().getLocalMap(Constants.RESULTS_MAP).put(imageIDSansExt, true);
 
                                 LOGGER.debug(MessageCodes.BUCKETEER_026, imageID);
                                 message.reply(Op.SUCCESS);

--- a/src/main/resources/bucketeer.yaml
+++ b/src/main/resources/bucketeer.yaml
@@ -20,7 +20,7 @@ paths:
       responses:
         '200':
           description: OK
-  /batch/jobs/{jobName}/{imageId}/{success}:
+  /batch/jobs/{job-name}/{image-id}/{success}:
     patch:
       summary: Batch Job Status
       description: Updates a batch job that's in process
@@ -34,13 +34,13 @@ paths:
           description: There was an internal server error
     parameters:
        - in: path
-         name: jobName
+         name: job-name
          required: true
          schema:
            type: string
          description: The batch job name
        - in: path
-         name: imageId
+         name: image-id
          required: true
          schema:
           type: string
@@ -62,7 +62,7 @@ paths:
             schema:
               type: object
               properties:
-                slackHandle:
+                slack-handle:
                   type: string
                 csvFileToUpload:
                   type: string
@@ -81,7 +81,7 @@ paths:
           description: Bad request (missing Slack handle/CSV file or invalid CSV uploaded)
         '415':
           description: Unsupported media type (i.e. not a CSV file)
-  /{imageId}/{filePath}:
+  /{image-id}/{file-path}:
     get:
       summary: New JPEG 2000 Image
       description: Requests a new image be loaded into Bucketeer's ingest workflow so that Cantaloupe can access it
@@ -102,13 +102,13 @@ paths:
                     description: Any related text about the loadImage operation
     parameters:
        - in: path
-         name: imageId
+         name: image-id
          required: true
          schema:
            type: string
          description: The image ID
        - in: path
-         name: filePath
+         name: file-path
          required: true
          schema:
           type: string

--- a/src/main/webroot/upload/csv/index.html
+++ b/src/main/webroot/upload/csv/index.html
@@ -51,7 +51,7 @@
               <input type="checkbox" name="failures" value="true"> Process previous failures only
             </div>
             <div class="form-group">
-              <label for="slackHandle">Slack Handle:</label> <input type="text" name="slackHandle" id="slackHandle">
+              <label for="slack-handle">Slack Handle:</label> <input type="text" name="slack-handle" id="slack-handle">
             </div>
             <div class="form-group">
               <input type="submit" value="Upload" name="submit">

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
+import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
@@ -61,9 +62,11 @@ public class BatchJobStatusHandlerTest {
 
     private static final String TEST_ARK = "ark%3A%2F13030%2Fhb000003n9";
 
-    private static final String JOB_NAME = "live-test.csv";
+    private static final String JOB_FILE_NAME = "live-test.csv";
 
     private static final String JOB_FILE_PATH = "src/test/resources/csv/";
+
+    private static final String JOB_NAME = FileUtils.stripExt(JOB_FILE_NAME);
 
     private static final String TRUE = "true";
 
@@ -208,15 +211,15 @@ public class BatchJobStatusHandlerTest {
     public final void testPatchHandle(final TestContext aContext) {
         final Async asyncTask = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
-        final String csvFile = new File(JOB_FILE_PATH, JOB_NAME).getAbsolutePath();
+        final String csvFile = new File(JOB_FILE_PATH, JOB_FILE_NAME).getAbsolutePath();
         final String patchUri = StringUtils.format(PATCH_BATCH_URI, JOB_NAME, TEST_ARK, TRUE);
         final WebClient webClient = WebClient.create(myVertx);
         final HttpRequest<Buffer> postRequest = webClient.post(port, UNSPECIFIED_HOST, POST_URI);
         final MultipartForm form = MultipartForm.create();
 
-        form.attribute("slackHandle", "ksclarke");
+        form.attribute(Constants.SLACK_HANDLE, "ksclarke");
         form.attribute("failure", "false");
-        form.textFileUpload("csvFileToUpload", JOB_NAME, csvFile, "text/csv");
+        form.textFileUpload("csvFileToUpload", JOB_FILE_NAME, csvFile, "text/csv");
 
         postRequest.sendMultipartForm(form, sendMultipartForm -> {
             if (sendMultipartForm.succeeded()) {

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
@@ -153,7 +153,7 @@ public class LoadImageHandlerTest {
 
                     // Check every 5 seconds to see if our process is done
                     myVertx.setPeriodic(5000, timer -> {
-                        if (myVertx.sharedData().getLocalMap(Constants.RESULTS_MAP).get(id + DOT_JPX) != null) {
+                        if (myVertx.sharedData().getLocalMap(Constants.RESULTS_MAP).get(id) != null) {
                             myAmazonS3.deleteObject(s3Bucket, id + DOT_JPX);
                             async.complete();
                         } else {


### PR DESCRIPTION
* Add batch job name to s3 uploaded user metadata
* Add image ID to s3 uploaded user metadata
* Change camel case to dash separated params to make their use consistent with S3 canonical user metadata naming rules
* Improved the consistency of use of named ID variables that are not used as file access points
* Update vertx-super-s3 dependency to v1.1.0 (which includes support for PUTing with user metadata)

NOTE: Travis test will fail because vertx-super-s3 dependency hasn't yet hit Maven Central. Will ping reviewers once it does and this PR is ready for review.