### PR TITLE
Fix failure to add invalidation path

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/verticles/ThumbnailVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/ThumbnailVerticle.java
@@ -92,11 +92,12 @@ public class ThumbnailVerticle extends AbstractBucketeerVerticle {
             final JsonArray thumbnailIDs = message.body().getJsonArray(Constants.IMAGE_ID_ARRAY);
             final String iiifURL = config.getString(Config.IIIF_URL);
 
-            thumbnailIDs.forEach(id -> {
+            for (int index = 0; index < thumbnailIDs.size(); index++) {
+                final String id = thumbnailIDs.getString(index);
                 final String iiifPath = StringUtils.format(INVALIDATION_TEMPLATE, id, tnSize);
 
                 futures.add(generateThumbnail(client, iiifURL, iiifPath, Future.future()));
-            });
+            }
 
             // We require at least one
             CompositeFuture.all(futures).setHandler(handler -> {


### PR DESCRIPTION
Small fix for an infrequent problem where the thumbnail invalidation path doesn't get added to the XML that's sent to CloudFront.