### PR TITLE
[IIIF-441] Encode the ID when it's added to access copy URL

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
@@ -2,6 +2,8 @@
 package edu.ucla.library.bucketeer.handlers;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
@@ -127,7 +129,7 @@ public class BatchJobStatusHandler extends AbstractBucketeerHandler {
                     }
 
                     metadata.setWorkflowState(WorkflowState.SUCCEEDED);
-                    metadata.setAccessCopy(iiif + id);
+                    metadata.setAccessCopy(iiif + URLEncoder.encode(id, StandardCharsets.UTF_8));
                 }
 
                 found = true;


### PR DESCRIPTION
Hopefully, the last in a series of URL encoding/decoding changes. Setting the ID in the access URL in the CSV is the last step in the process.

These changes were caused when we corrected our assumption that ARKs would be URL encoded in the CSVs. They won't be.