### PR TITLE
[IIIF-455] Skip items that don't have a source file

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/Item.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Item.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
 
 import edu.ucla.library.bucketeer.Job.WorkflowState;
@@ -26,6 +28,8 @@ public class Item implements Serializable {
      * The <code>serialVersionUID</code> of the Item.
      */
     private static final long serialVersionUID = 2062164135217237338L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Item.class, Constants.MESSAGES);
 
     private String myID;
 
@@ -110,13 +114,17 @@ public class Item implements Serializable {
      */
     @JsonIgnore
     public File getFile() {
-        File file = new File(StringUtils.trimTo(myFilePath, ""));
+        if (!hasFile()) {
+            return null;
+        } else {
+            File file = new File(StringUtils.trimTo(myFilePath, ""));
 
-        if (myFilePathPrefix != null) {
-            file = Paths.get(myFilePathPrefix.getPrefix(file), file.getPath()).toFile();
+            if (myFilePathPrefix != null) {
+                file = Paths.get(myFilePathPrefix.getPrefix(file), file.getPath()).toFile();
+            }
+
+            return file;
         }
-
-        return file;
     }
 
     /**
@@ -125,7 +133,7 @@ public class Item implements Serializable {
      * @return The file path
      */
     public String getFilePath() throws IOException {
-        return getFile().getCanonicalPath();
+        return hasFile() ? getFile().getCanonicalPath() : null;
     }
 
     /**
@@ -134,7 +142,12 @@ public class Item implements Serializable {
      * @param aFilePath A file path
      */
     public Item setFilePath(final String aFilePath) {
-        myFilePath = aFilePath;
+        if (!hasFile()) {
+            throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.BUCKETEER_053, myID));
+        } else {
+            myFilePath = aFilePath;
+        }
+
         return this;
     }
 
@@ -145,7 +158,7 @@ public class Item implements Serializable {
      */
     @JsonIgnore
     public boolean fileExists() {
-        return getFile().exists();
+        return myFilePath == null ? false : getFile().exists();
     }
 
     /**

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
@@ -256,7 +256,6 @@ public class LoadCsvHandler implements Handler<RoutingContext> {
             final boolean isOkayInitialRun = !aJob.getIsSubsequentRun() && state.equals(Job.WorkflowState.EMPTY);
             final boolean isOkaySubsequentRun = aJob.getIsSubsequentRun() && state.equals(Job.WorkflowState.FAILED);
 
-            //
             // For normal runs only process empty states and for failure runs only processes failures
             if (item.hasFile() && (isOkayInitialRun || isOkaySubsequentRun)) {
                 s3UploadMessage.put(Constants.IMAGE_ID, item.getID() + "." + FileUtils.getExt(imageFile.getName()));

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
@@ -256,14 +256,19 @@ public class LoadCsvHandler implements Handler<RoutingContext> {
             final boolean isOkayInitialRun = !aJob.getIsSubsequentRun() && state.equals(Job.WorkflowState.EMPTY);
             final boolean isOkaySubsequentRun = aJob.getIsSubsequentRun() && state.equals(Job.WorkflowState.FAILED);
 
+            //
             // For normal runs only process empty states and for failure runs only processes failures
-            if (isOkayInitialRun || isOkaySubsequentRun) {
+            if (item.hasFile() && (isOkayInitialRun || isOkaySubsequentRun)) {
                 s3UploadMessage.put(Constants.IMAGE_ID, item.getID() + "." + FileUtils.getExt(imageFile.getName()));
                 s3UploadMessage.put(Constants.FILE_PATH, imageFile.getAbsolutePath());
                 s3UploadMessage.put(Constants.JOB_NAME, aJob.getName());
                 s3UploadMessage.put(Config.S3_BUCKET, s3Bucket);
 
                 sendMessage(s3UploadMessage, S3BucketVerticle.class.getName(), Integer.MAX_VALUE);
+            } else {
+                final String filePath = imageFile == null ? "null" : imageFile.getAbsolutePath();
+
+                LOGGER.debug(MessageCodes.BUCKETEER_054, item.getID(), filePath, state);
             }
         }
     }

--- a/src/main/java/edu/ucla/library/bucketeer/utils/JobFactory.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/JobFactory.java
@@ -13,6 +13,7 @@ import com.opencsv.CSVReader;
 import info.freelibrary.util.BufferedFileReader;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
 
 import edu.ucla.library.bucketeer.Constants;
 import edu.ucla.library.bucketeer.CsvParsingException;
@@ -100,7 +101,16 @@ public final class JobFactory {
                             csvParsingException.addMessage(MessageCodes.BUCKETEER_123);
                             break;
                         } else if (fileNameIndex == columnIndex) {
-                            item.setFilePath(columns[columnIndex]);
+                            final String filePath = StringUtils.trimToNull(columns[columnIndex]);
+
+                            // Items have files by default so it may just be that hasFile(false) has not yet been set
+                            if (item.hasFile()) {
+                                if (filePath != null) {
+                                    item.setFilePath(columns[columnIndex]);
+                                } else {
+                                    item.setFilePath("");
+                                }
+                            }
                         } else if (itemIdIndex == columnIndex) {
                             item.setID(columns[columnIndex]);
                         } else if (bucketeerStateIndex == columnIndex) {

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -61,6 +61,8 @@
   <entry key="BUCKETEER-050">Form submission is missing a Slack handle.</entry>
   <entry key="BUCKETEER-051">Slack user '{}' uploaded CSV file '{}' to: {}</entry>
   <entry key="BUCKETEER-052">CSV contains an entry that is not a work or collection: {}</entry>
+  <entry key="BUCKETEER-053">Trying to set a file on an item that is set to not have a file: {}</entry>
+  <entry key="BUCKETEER-054">Skipping processing for: {} - {} [{}]</entry>
   <entry key="BUCKETEER-055">Invalid CSV line: {}</entry>
   <entry key="BUCKETEER-056">Failed to create test file needed for testing: {}</entry>
   <entry key="BUCKETEER-057">Unable to delete test file used in testing: {}</entry>


### PR DESCRIPTION
I introduced a bug with the last commit where Collection items were no longer skipped like they should be. This PR rectifies that and skips items that have specifically had hasFile() set to false (what we do when parsing Collection records from the CSV).