### PR TITLE
[IIIF-459] Make Job's Item statuses the source of truth

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandler.java
@@ -62,10 +62,17 @@ public class GetJobStatusesHandler extends AbstractBucketeerHandler {
                                         for (int index = 0; index < items.size(); index++) {
                                             final Item item = items.get(index);
                                             final JsonObject image = new JsonObject();
+                                            final String filePath;
+
+                                            if (item.hasFile()) {
+                                                filePath = item.getFile().getCanonicalPath();
+                                            } else {
+                                                filePath = "";
+                                            }
 
                                             image.put(Constants.IMAGE_ID, item.getID());
                                             image.put(Constants.STATUS, item.getWorkflowState().toString());
-                                            image.put(Constants.FILE_PATH, item.getFile().getCanonicalPath());
+                                            image.put(Constants.FILE_PATH, filePath);
 
                                             images.add(image);
                                         }

--- a/src/main/java/edu/ucla/library/bucketeer/utils/IFilePathPrefix.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/IFilePathPrefix.java
@@ -4,9 +4,12 @@ package edu.ucla.library.bucketeer.utils;
 import java.io.File;
 import java.io.Serializable;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 /**
  * An interface for providing a file path prefix to use with an object's metadata.
  */
+@JsonDeserialize(using = PrefixDeserializer.class)
 public interface IFilePathPrefix extends Serializable {
 
     /**

--- a/src/main/java/edu/ucla/library/bucketeer/utils/JobFactory.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/JobFactory.java
@@ -127,6 +127,13 @@ public final class JobFactory {
                             // Note if we're not expecting this column to have a source file
                             if (Metadata.COLLECTION.equals(columns[columnIndex])) {
                                 item.hasFile(false);
+
+                                // If we don't have a source file to process, we can mark this done
+                                if (WorkflowState.SUCCEEDED.equals(item.getWorkflowState())) {
+                                    item.setWorkflowState(WorkflowState.INGESTED);
+                                } else {
+                                    item.setWorkflowState(WorkflowState.SUCCEEDED);
+                                }
                             }
                         }
                     }

--- a/src/main/java/edu/ucla/library/bucketeer/utils/PrefixDeserializer.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/PrefixDeserializer.java
@@ -1,0 +1,63 @@
+
+package edu.ucla.library.bucketeer.utils;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.bucketeer.Constants;
+import edu.ucla.library.bucketeer.MessageCodes;
+
+/**
+ * A deserializer for classes implementing <code>IFilePathPrefix</code>.
+ */
+public class PrefixDeserializer extends StdDeserializer<IFilePathPrefix> {
+
+    /**
+     * The <code>serialVersionUID<code> for <code>PrefixDeserializer</code>
+     */
+    private static final long serialVersionUID = 6823136469689445963L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrefixDeserializer.class, Constants.MESSAGES);
+
+    /**
+     * Creates a file path prefix deserializer.
+     */
+    public PrefixDeserializer() {
+        this(null);
+    }
+
+    /**
+     * Creates a file path prefix deserializer.
+     *
+     * @param aClass A class to deserialize
+     */
+    public PrefixDeserializer(final Class<?> aClass) {
+        super(aClass);
+    }
+
+    @Override
+    public IFilePathPrefix deserialize(final JsonParser aParser, final DeserializationContext aContext)
+            throws IOException, JsonProcessingException {
+        final JsonNode node = aParser.getCodec().readTree(aParser);
+        final String fieldName = node.fieldNames().next();
+
+        // TODO: We can get fancier with this in the future
+        switch (fieldName) {
+            case "uclaRootDir":
+                return new UCLAFilePathPrefix(node.get(fieldName).asText());
+            case "genericRootDir":
+                return new GenericFilePathPrefix(node.get(fieldName).asText());
+            default:
+                LOGGER.warn(MessageCodes.BUCKETEER_127, GenericFilePathPrefix.class.getSimpleName());
+                return new GenericFilePathPrefix();
+        }
+    }
+}

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -87,7 +87,7 @@
   <entry key="BUCKETEER-076">Unable to get job from jobs queue: {}</entry>
   <entry key="BUCKETEER-077">Received an ID for an image that isn't in our '{}' jobs queue: {}</entry>
   <entry key="BUCKETEER-078">The batch job for converting images from '{}' has been completed</entry>
-  <entry key="BUCKETEER-079">Discrepancy over whether this is the last job in the '{}' batch</entry>
+  <entry key="BUCKETEER-079">Completed '{}' job, but with a discrepancy between counter and item statuses</entry>
   <entry key="BUCKETEER-080">Unable to decrement job counter for: {}</entry>
   <entry key="BUCKETEER-081">Finished processing the batch job for '{}'</entry>
   <entry key="BUCKETEER-082">Failed to removed completed batch job from the queue: {}</entry>
@@ -135,4 +135,5 @@
   <entry key="BUCKETEER-124">Unexpected workflow state: {}</entry>
   <entry key="BUCKETEER-125">Item '{}' is missing a source file: {}</entry>
   <entry key="BUCKETEER-126">CSV input errors in '{}': {}</entry>
+  <entry key="BUCKETEER-127">Didn't find a custom file path prefix deserializer, so using a generic one: {}</entry>
 </properties>


### PR DESCRIPTION
* Make job's item statuses the source of truth for job completion
* Set workflow state on Collection items too (even though they don't have images)
* Created custom Jackson serializer for classes implementing IFilePathPrefix
* Fix hasFile() issue with displaying workflow statuses in monitoring endpoint