### PR TITLE
Fail an item if it doesn't have a file set

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/utils/JobFactory.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/JobFactory.java
@@ -140,6 +140,7 @@ public final class JobFactory {
                                     item.setFilePath(columns[columnIndex]);
                                 } else {
                                     item.setFilePath("");
+                                    item.setWorkflowState(WorkflowState.FAILED);
                                 }
                             }
                         } else if (itemIdIndex == columnIndex) {


### PR DESCRIPTION
If an item doesn't have a file, it needs to be failed so it doesn't hang the batch job result.