### PR TITLE
[IIIF-468] Fix broken Masters logic

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/utils/UCLAFilePathPrefix.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/UCLAFilePathPrefix.java
@@ -49,7 +49,7 @@ public class UCLAFilePathPrefix implements IFilePathPrefix {
         final String path;
 
         if (aFile.getPath().startsWith(MASTERS_DIR_PATH)) {
-            path = Paths.get(myUCLARootDir, MASTERS_DIR_PATH).toString();
+            path = Paths.get(myUCLARootDir).toString();
         } else {
             path = Paths.get(myUCLARootDir, DL_MASTERS_DIR_PATH).toString();
         }

--- a/src/test/java/edu/ucla/library/bucketeer/utils/UCLAFilePathPrefixTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/utils/UCLAFilePathPrefixTest.java
@@ -29,6 +29,6 @@ public class UCLAFilePathPrefixTest {
      */
     @Test
     public final void testGetPrefixMasters() {
-        assertEquals("/mnt/ucla/Masters", new UCLAFilePathPrefix(ROOT_PATH).getPrefix(MASTERS_TEST_FILE));
+        assertEquals(ROOT_PATH, new UCLAFilePathPrefix(ROOT_PATH).getPrefix(MASTERS_TEST_FILE));
     }
 }


### PR DESCRIPTION
If a file path starts with Masters, we shouldn't be adding it, just use the root dir + the file path.