### PR TITLE
[IIIIF-353] revise existing LoadImageHandlerTest and ImageUploadIT to use a UTF8-encoded filename

### DIFF
--- a/src/test/java/edu/ucla/library/bucketeer/ImageUploadIT.java
+++ b/src/test/java/edu/ucla/library/bucketeer/ImageUploadIT.java
@@ -55,7 +55,7 @@ public class ImageUploadIT {
 
     private static final String DEFAULT_S3_BUCKET = "cantaloupe-jp2k";
 
-    private static final String TEST_FILE_PATH = "src/test/resources/images/test.tif";
+    private static final String TEST_FILE_PATH = "src/test/resources/images/熵.tif";
 
     private static final String SLASH = "/";
 
@@ -156,7 +156,7 @@ public class ImageUploadIT {
         // if we don't Have Kakadu installed, we *should* fail, but we will instead be crafty
         canRunKakadu = ConverterFactory.hasSystemKakadu();
 
-        // let's use our test.tif file
+        // let's use our 熵.tif file
         myTIFF = new File(TEST_FILE_PATH);
         final String defaultTestFileName = myTIFF.getName();
         LOGGER.debug(MessageCodes.BUCKETEER_035, defaultTestFileName);

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
@@ -129,7 +129,7 @@ public class LoadImageHandlerTest {
     public void confirmLoadImageHandlerResponseMatchesSpec(final TestContext aContext) {
         final Async async = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
-        final String encodedImagePath = "/test/src%2Ftest%2Fresources%2Fimages%2Ftest.tif";
+        final String encodedImagePath = "/test/src%2Ftest%2Fresources%2Fimages%2F熵.tif";
         final RequestOptions request = new RequestOptions();
 
         request.setPort(port).setHost(Constants.UNSPECIFIED_HOST).setURI(encodedImagePath);
@@ -145,7 +145,7 @@ public class LoadImageHandlerTest {
 
                     aContext.assertEquals(jsonConfirm.getString(Constants.IMAGE_ID), id);
                     aContext.assertEquals(jsonConfirm.getString(Constants.FILE_PATH),
-                            "src/test/resources/images/test.tif");
+                            "src/test/resources/images/熵.tif");
 
                     jsonConfirm.put(Constants.WAIT_COUNT, 0);
 


### PR DESCRIPTION
* revise existing unit and integration tests to use a file with a UTF-8-encoded filename