### PR TITLE
[IIIF-408] Make home page config opts runtime populated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,6 @@
               <resources>
                 <resource>
                   <directory>${basedir}/src/main/webroot</directory>
-                  <filtering>true</filtering>
                 </resource>
               </resources>
             </configuration>

--- a/src/main/java/edu/ucla/library/bucketeer/Op.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Op.java
@@ -14,6 +14,8 @@ public final class Op {
 
     public static final String GET_JOBS = "getJobs";
 
+    public static final String GET_CONFIG = "getConfig";
+
     public static final String GET_JOB_STATUSES = "getJobStatuses";
 
     public static final String DELETE_JOB = "deleteJob";

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/GetConfigHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/GetConfigHandler.java
@@ -1,0 +1,76 @@
+
+package edu.ucla.library.bucketeer.handlers;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.bucketeer.Config;
+import edu.ucla.library.bucketeer.Constants;
+import edu.ucla.library.bucketeer.HTTP;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Gets a list of in-progress jobs.
+ */
+public class GetConfigHandler extends AbstractBucketeerHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetConfigHandler.class, Constants.MESSAGES);
+
+    private final JsonObject myConfig;
+
+    /**
+     * Constructs the GetConfigHandler.
+     *
+     * @param aConfig
+     */
+    public GetConfigHandler(final JsonObject aConfig) {
+        myConfig = aConfig;
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final HttpServerResponse response = aContext.response();
+        final JsonObject viewableConfig = new JsonObject();
+        final String iiifURL = myConfig.getString(Config.IIIF_URL);
+        final String fsMount = myConfig.getString(Config.FILESYSTEM_MOUNT);
+        final String tnSize = myConfig.getString(Config.THUMBNAIL_SIZE);
+        final String lambdaBucket = myConfig.getString(Config.LAMBDA_S3_BUCKET);
+        final String s3Bucket = myConfig.getString(Config.S3_BUCKET);
+        final String s3Region = myConfig.getString(Config.S3_REGION);
+
+        if (iiifURL != null) {
+            viewableConfig.put("bucketeer-iiif-url", iiifURL);
+        }
+
+        if (tnSize != null) {
+            viewableConfig.put("bucketeer-tn-size", tnSize);
+        }
+
+        if (fsMount != null) {
+            viewableConfig.put("bucketeer-fs-mount", fsMount);
+        }
+
+        if (s3Region != null) {
+            viewableConfig.put("bucketeer-s3-region", s3Region);
+        }
+
+        if (s3Bucket != null) {
+            viewableConfig.put("bucketeer-s3-bucket", s3Bucket);
+        }
+
+        if (lambdaBucket != null) {
+            viewableConfig.put("lambda-s3-bucket", lambdaBucket);
+        }
+
+        response.setStatusCode(HTTP.OK);
+        response.end(viewableConfig.encodePrettily());
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
+
+}

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/MainVerticle.java
@@ -16,6 +16,7 @@ import edu.ucla.library.bucketeer.Op;
 import edu.ucla.library.bucketeer.handlers.BatchJobStatusHandler;
 import edu.ucla.library.bucketeer.handlers.DeleteJobHandler;
 import edu.ucla.library.bucketeer.handlers.FailureHandler;
+import edu.ucla.library.bucketeer.handlers.GetConfigHandler;
 import edu.ucla.library.bucketeer.handlers.GetJobStatusesHandler;
 import edu.ucla.library.bucketeer.handlers.GetJobsHandler;
 import edu.ucla.library.bucketeer.handlers.GetStatusHandler;
@@ -122,6 +123,7 @@ public class MainVerticle extends AbstractVerticle {
 
                     // Next, we associate handlers with routes from our specification
                     routerFactory.addHandlerByOperationId(Op.GET_STATUS, new GetStatusHandler());
+                    routerFactory.addHandlerByOperationId(Op.GET_CONFIG, new GetConfigHandler(aConfig));
                     routerFactory.addHandlerByOperationId(Op.GET_JOBS, new GetJobsHandler());
                     routerFactory.addHandlerByOperationId(Op.GET_JOB_STATUSES, new GetJobStatusesHandler());
                     routerFactory.addHandlerByOperationId(Op.DELETE_JOB, new DeleteJobHandler());

--- a/src/main/resources/bucketeer.yaml
+++ b/src/main/resources/bucketeer.yaml
@@ -36,7 +36,7 @@ paths:
           description: There was an internal server error
   /config:
     get:
-      summary: Get viewable config
+      summary: Get Viewable Config
       description: A listing of all configuration options that are publicly viewable
       operationId: getConfig
       responses:

--- a/src/main/resources/bucketeer.yaml
+++ b/src/main/resources/bucketeer.yaml
@@ -34,6 +34,39 @@ paths:
               example: Hello
         '500':
           description: There was an internal server error
+  /config:
+    get:
+      summary: Get viewable config
+      description: A listing of all configuration options that are publicly viewable
+      operationId: getConfig
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bucketeer-iiif-url:
+                    type: string
+                    example: http://bucketeer.library.ucla.edu
+                  bucketeer-s3-region:
+                    type: string
+                    example: us-west-1
+                  bucketeer-s3-bucket:
+                    type: string
+                    example: bucketeer-bucket
+                  lambda-s3-bucket:
+                    type: string
+                    example: bucketeer-lambda-bucket
+                  bucketeer-fs-mount:
+                    type: string
+                    example: bucketeer-fs-mount
+                  bucketeer-tn-size:
+                    type: string
+                    example: '!200,200'
+        '500':
+          description: There was an internal server error
   /batch/jobs:
     get:
       summary: Get Jobs in Progress

--- a/src/main/webroot/index.html
+++ b/src/main/webroot/index.html
@@ -64,18 +64,54 @@
           other values:</p>
         <dl>
           <dt>IIIF Server</dt>
-          <dd>${bucketeer.iiif.url}</dd>
+          <dd id="bucketeer-iiif-url">Unknown</dd>
           <dt>S3 Bucket</dt>
-          <dd>${bucketeer.s3.bucket}</dd>
+          <dd id="bucketeer-s3-bucket">Unknown</dd>
           <dt>S3 Bucket Region</dt>
-          <dd>${bucketeer.s3.region}</dd>
+          <dd id="bucketeer-s3-region">Unknown</dd>
           <dt>AWS Lambda S3 Bucket for TIFFs</dt>
-          <dd>${lambda.s3.bucket}</dd>
+          <dd id="lambda-s3-bucket">Unknown</dd>
           <dt>Local file system mount</dt>
-          <dd>${bucketeer.fs.mount}</dd>
+          <dd id="bucketeer-fs-mount">Unknown</dd>
           <dt>Thumbnail Size / Dimensions</dt>
-          <dd>${bucketeer.thumbnail.size}</dd>
+          <dd id="bucketeer-tn-size">Unknown</dd>
         </dl>
+        <script>
+          var xhttp = new XMLHttpRequest();
+
+          xhttp.onreadystatechange = function() {
+            if (xhttp.readyState == 4 && xhttp.status == 200) {
+              var json = JSON.parse(xhttp.responseText);
+
+              if (json["bucketeer-iiif-url"]) {
+                document.getElementById("bucketeer-iiif-url").textContent = json["bucketeer-iiif-url"];
+              }
+
+              if (json["bucketeer-s3-bucket"]) {
+                document.getElementById("bucketeer-s3-bucket").textContent = json["bucketeer-s3-bucket"];
+              }
+
+              if (json["bucketeer-s3-region"]) {
+                document.getElementById("bucketeer-s3-region").textContent = json["bucketeer-s3-region"];
+              }
+
+              if (json["lambda-s3-bucket"]) {
+                document.getElementById("lambda-s3-bucket").textContent = json["lambda-s3-bucket"];
+              }
+
+              if (json["bucketeer-fs-mount"]) {
+                document.getElementById("bucketeer-fs-mount").textContent = json["bucketeer-fs-mount"];
+              }
+
+              if (json["bucketeer-tn-size"]) {
+                document.getElementById("bucketeer-tn-size").textContent = json["bucketeer-tn-size"];
+              }
+            }
+          };
+
+          xhttp.open("GET", "/config", true);
+          xhttp.send();
+        </script>
       </div>
       <div class="col-sm-8">
         <h4>Learn more about Bucketeer</h4>


### PR DESCRIPTION
Populate the home page config options at runtime instead of build time. This adds a new `/config` endpoint to the app (and so OpenAPI spec, documentation, etc.)