### PR TITLE
[IIIF-525] Check previous run collection states

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/JobFactory.java
+++ b/src/main/java/edu/ucla/library/bucketeer/JobFactory.java
@@ -175,7 +175,10 @@ public final class JobFactory {
                             item.setID(columns[columnIndex]);
                         } else if (bucketeerStateIndex == columnIndex) {
                             try {
-                                item.setWorkflowState(WorkflowState.fromString(columns[columnIndex]));
+                                // Structural state is new so let's not overwrite with older values
+                                if (!WorkflowState.STRUCTURAL.equals(item.getWorkflowState())) {
+                                    item.setWorkflowState(WorkflowState.fromString(columns[columnIndex]));
+                                }
                             } catch (final IllegalArgumentException details) {
                                 // Adding an error sets the workflow state to failed
                                 error.addMessage(MessageCodes.BUCKETEER_124, columns[columnIndex]);

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
@@ -270,6 +270,15 @@ public class LoadCsvHandler extends AbstractBucketeerHandler {
 
                 // We might be skipping because there is no file to process or because it's already been done
                 LOGGER.debug(MessageCodes.BUCKETEER_054, item.getID(), aJob.getName(), filePath, state);
+
+                // We can't let an empty state go through without an S3 upload attempt
+                if (WorkflowState.EMPTY.equals(state)) {
+                    if (filePath.equals(missingFileMessage)) {
+                        item.setWorkflowState(WorkflowState.MISSING);
+                    } else {
+                        item.setWorkflowState(WorkflowState.FAILED);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
We have some older CSVs that have other values for structural rows. We want to make sure we don't preserve those values, but use the new STRUCTURAL state.