### PR TITLE
[IIIF-786] Add source file size check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
   directories:
   - $HOME/.m2
 
+bundler_args: --retry 5
+
 jobs:
   include:
     - stage: Build and Test on OpenJDK11

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ branches:
   - master
   - /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/
 
+cache:
+  directories:
+  - $HOME/.m2
+
 jobs:
   include:
     - stage: Build and Test on OpenJDK11
@@ -12,10 +16,10 @@ jobs:
       jdk:
         - openjdk11
       install:
-        - mvn package -q -Dmaven.test.skip -Dmaven.javadoc.skip -B -V
+        - mvn help:active-profiles package -q -Dmaven.test.skip -Dmaven.javadoc.skip -B -V
       script:
         - >
-          mvn help:active-profiles verify \
+          travis_retry mvn verify \
             -Dbucketeer.s3.access_key="${AWS_ACCESS_KEY_ID}" \
             -Dbucketeer.s3.secret_key="${AWS_SECRET_ACCESS_KEY}" \
             -Dbucketeer.s3.region="${BUCKETEER_S3_REGION}" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
   directories:
   - $HOME/.m2
 
-bundler_args: --retry 5
-
 jobs:
   include:
     - stage: Build and Test on OpenJDK11

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,7 @@
     <developer>
       <id>hardyoyo</id>
       <name>Hardy Pottinger</name>
-      <email>hpottinger@library.ucla.edu</email>
-      <organization>UCLA Library</organization>
-      <organizationUrl>http://github.com/uclalibrary</organizationUrl>
+      <email>hardy.pottinger@gmail.com</email>
     </developer>
     <developer>
       <id>cachemeoutside</id>
@@ -117,6 +115,9 @@
 
     <!-- Thumbnail size for images served by the IIIF server -->
     <bucketeer.thumbnail.size>!200,200</bucketeer.thumbnail.size>
+
+    <!-- The maximum size TIFF image we'll attempt to process; default: 300 MB -->
+    <bucketeer.max.source.file.size>300000000</bucketeer.max.source.file.size>
 
     <!-- Where the source images are mounted on the local file system -->
     <bucketeer.fs.mount>.</bucketeer.fs.mount>
@@ -465,11 +466,10 @@
         <configuration>
           <excludes>
             <exclude>**/*IT.java</exclude>
-            <exclude>**/*IntegrationTest.java</exclude>
-            <!-- Temporarily disable problematic test -->
-            <exclude>**/BatchJobStatusHandlerTest.java</exclude>
           </excludes>
-          <forkCount>2</forkCount>
+          <forkCount>0</forkCount>
+          <useSystemClassLoader>false</useSystemClassLoader>
+          <skipAfterFailureCount>1</skipAfterFailureCount>
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
             <vertx.test.port>${http.port}</vertx.test.port>

--- a/src/main/java/edu/ucla/library/bucketeer/Config.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Config.java
@@ -30,6 +30,9 @@ public final class Config {
     // Thumbnail size for pre-caching thumbnails
     public static final String THUMBNAIL_SIZE = "bucketeer.thumbnail.size";
 
+    // The maximum size TIFF image we'll attempt to process
+    public static final String MAX_SOURCE_SIZE = "bucketeer.max.source.file.size";
+
     // Configuration options for the S3 upload verticle(s)
     public static final String S3_MAX_REQUESTS = "s3.max.requests";
 

--- a/src/main/java/edu/ucla/library/bucketeer/HTTP.java
+++ b/src/main/java/edu/ucla/library/bucketeer/HTTP.java
@@ -21,6 +21,9 @@ public final class HTTP {
     /** Not found response */
     public static final int NOT_FOUND = 404;
 
+    /** Method not allowed */
+    public static final int METHOD_NOT_ALLOWED = 405;
+
     /** Generic internal server error */
     public static final int INTERNAL_SERVER_ERROR = 500;
 

--- a/src/main/java/edu/ucla/library/bucketeer/Item.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Item.java
@@ -53,7 +53,7 @@ public class Item implements Serializable {
      * Creates new item.
      */
     public Item() {
-        // Used in deserialization
+        // Used in deserialization and testing
     }
 
     /**
@@ -169,7 +169,6 @@ public class Item implements Serializable {
                 filePath = myFilePath.get();
                 file = Paths.get(myFilePathPrefix.getPrefix(new File(filePath)), filePath).toFile();
             } else {
-                LOGGER.warn(MessageCodes.BUCKETEER_128);
                 file = new File(myFilePath.get());
             }
 
@@ -191,7 +190,7 @@ public class Item implements Serializable {
             if (file.isEmpty()) {
                 myPrefixedFilePath = Optional.empty();
             } else {
-                myPrefixedFilePath = Optional.of(file.get().getAbsolutePath());
+                myPrefixedFilePath = Optional.of(Paths.get(file.get().getAbsolutePath()).normalize().toString());
             }
         }
 
@@ -203,7 +202,7 @@ public class Item implements Serializable {
      *
      * @return The file path
      */
-    public Optional<String> getFilePath() throws IOException {
+    public Optional<String> getFilePath() {
         return myFilePath;
     }
 

--- a/src/main/java/edu/ucla/library/bucketeer/JobFactory.java
+++ b/src/main/java/edu/ucla/library/bucketeer/JobFactory.java
@@ -70,6 +70,7 @@ public final class JobFactory {
      * @param aCsvFile A CSV file containing the job's metadata
      * @return A new batch job
      * @throws IOException If there is trouble reading the CSV file
+     * @throws ProcessingException If there is trouble processing the CSV file
      */
     public Job createJob(final String aName, final File aCsvFile) throws IOException, ProcessingException {
         return createJob(aName, aCsvFile, false);
@@ -83,6 +84,7 @@ public final class JobFactory {
      * @param aSubsequentRun If the job to be created is a subsequent run
      * @return A new batch job
      * @throws IOException If there is trouble reading the CSV file
+     * @throws ProcessingException If there is trouble processing the CSV file
      */
     @SuppressWarnings({ "PMD.ExcessiveMethodLength", "PMD.NcssCount" })
     public Job createJob(final String aName, final File aCsvFile, final boolean aSubsequentRun) throws IOException,

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
@@ -3,7 +3,6 @@ package edu.ucla.library.bucketeer.handlers;
 
 import static edu.ucla.library.bucketeer.Constants.EMPTY;
 
-import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
@@ -48,7 +47,7 @@ public class BatchJobStatusHandler extends AbstractBucketeerHandler {
      *
      * @param aConfig An application configuration
      */
-    public BatchJobStatusHandler(final JsonObject aConfig) throws IOException {
+    public BatchJobStatusHandler(final JsonObject aConfig) {
         myConfig = aConfig;
     }
 

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -91,7 +91,7 @@
   <entry key="BUCKETEER-080">Unable to decrement job counter for: {}</entry>
   <entry key="BUCKETEER-081">Finished processing the batch job for '{}'</entry>
   <entry key="BUCKETEER-082">Failed to removed completed batch job from the queue: {}</entry>
-  <entry key="BUCKETEER-083">BatchJobStatusHandlerTest should have failed with a GET request</entry>
+  <entry key="BUCKETEER-083">BatchJobStatusHandlerTest failed with unexpected response code: {} [{}]</entry>
   <entry key="BUCKETEER-084">FakeS3BucketVerticle received a storage request: {}</entry>
   <entry key="BUCKETEER-085">Setting up the Slack client</entry>
   <entry key="BUCKETEER-086">Preparing to send '{}' to Slack channel: {}</entry>

--- a/src/test/java/edu/ucla/library/bucketeer/ImageUploadIT.java
+++ b/src/test/java/edu/ucla/library/bucketeer/ImageUploadIT.java
@@ -206,8 +206,8 @@ public class ImageUploadIT {
                 try {
                     TimeUnit.SECONDS.sleep(5);
                 } catch (final InterruptedException details) {
-                    // this is just here so we can interrupt our way out of this loop
-                    details.printStackTrace(); // we might consider using a logger instead of this?
+                    aContext.fail(details);
+                    break;
                 }
 
                 LOGGER.debug(MessageCodes.BUCKETEER_037, counter);

--- a/src/test/java/edu/ucla/library/bucketeer/ImageUploadIT.java
+++ b/src/test/java/edu/ucla/library/bucketeer/ImageUploadIT.java
@@ -1,10 +1,6 @@
 
 package edu.ucla.library.bucketeer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -93,16 +89,17 @@ public class ImageUploadIT {
      */
     @BeforeClass
     public static void configureS3(final TestContext aContext) {
+        final ConfigRetriever configRetriever = ConfigRetriever.create(vertx);
         final Async asyncTask = aContext.async();
 
         LOGGER.debug(MessageCodes.BUCKETEER_021, ImageUploadIT.class.getSimpleName(), PORT);
 
-        final ConfigRetriever configRetriever = ConfigRetriever.create(vertx);
-
         configRetriever.getConfig(config -> {
             if (config.succeeded()) {
-                LOGGER.debug(MessageCodes.BUCKETEER_038);
                 final JsonObject jsonConfig = config.result();
+
+                LOGGER.debug(MessageCodes.BUCKETEER_038);
+
                 myS3Bucket = jsonConfig.getString(Config.S3_BUCKET, DEFAULT_S3_BUCKET);
                 myS3AccessKey = jsonConfig.getString(Config.S3_ACCESS_KEY, DEFAULT_ACCESS_KEY);
                 myS3SecretKey = jsonConfig.getString(Config.S3_SECRET_KEY, DEFAULT_SECRET_KEY);
@@ -127,15 +124,16 @@ public class ImageUploadIT {
     @Test
     public final void checkThatServiceIsUp(final TestContext aContext) {
         final Async asyncTask = aContext.async();
-        // first, let's sanity-check our service status check endpoint before we do anything real
+
         vertx.createHttpClient().getNow(PORT, Constants.UNSPECIFIED_HOST, STATUS_CHECK, response -> {
-            // validate the response
-            myStatusCode = response.statusCode();
-            aContext.assertEquals(HTTP.OK, myStatusCode);
+            aContext.assertEquals(HTTP.OK, response.statusCode());
+
             response.bodyHandler(body -> {
                 aContext.assertEquals(body.getString(0, body.length()), HELLO);
-                LOGGER.debug("Bucketeer service confirmed to be available.");
-                asyncTask.complete();
+
+                if (!asyncTask.isCompleted()) {
+                    asyncTask.complete();
+                }
             });
         });
     }
@@ -143,20 +141,22 @@ public class ImageUploadIT {
     /**
      * check that we can load an image
      *
-     * @throws UnsupportedEncodingException
-     * @throws ConfigurationException
+     * @throws UnsupportedEncodingException If the encoding isn't supported by the JVM
+     * @throws SdkClientException If there is trouble using the AWS SDK
+     * @throws AmazonServiceException If there is trouble interacting with the AWS service
      */
     @SuppressWarnings("deprecation")
     @Test
-    public final void checkThatWeCanLoadAnImage() throws UnsupportedEncodingException, SdkClientException,
-            AmazonServiceException {
+    public final void checkThatWeCanLoadAnImage(final TestContext aContext) throws UnsupportedEncodingException,
+            SdkClientException, AmazonServiceException {
+        final String defaultTestFileName;
 
         // if we don't Have Kakadu installed, we *should* fail, but we will instead be crafty
         canRunKakadu = ConverterFactory.hasSystemKakadu();
 
         // let's use our 熵.tif file
         myTIFF = new File(TEST_FILE_PATH);
-        final String defaultTestFileName = myTIFF.getName();
+        defaultTestFileName = myTIFF.getName();
         LOGGER.debug(MessageCodes.BUCKETEER_035, defaultTestFileName);
 
         if (canRunKakadu) {
@@ -175,13 +175,14 @@ public class ImageUploadIT {
 
         // attempt to load our image and verify the response is OK
         vertx.createHttpClient().getNow(PORT, Constants.UNSPECIFIED_HOST, myImageLoadRequest, response -> {
-            // validate the response
             myStatusCode = response.statusCode();
-            assertEquals(myStatusCode, HTTP.OK);
+            aContext.assertEquals(myStatusCode, HTTP.OK);
+
             response.bodyHandler(body -> {
                 final JsonObject jsonConfirm = new JsonObject(body.getString(0, body.length()));
-                assertEquals(jsonConfirm.getString(Constants.IMAGE_ID), myUUID);
-                assertFalse(jsonConfirm.getString(Constants.IMAGE_ID).equals("pickles"));
+
+                aContext.assertEquals(jsonConfirm.getString(Constants.IMAGE_ID), myUUID);
+                aContext.assertFalse(jsonConfirm.getString(Constants.IMAGE_ID).equals("pickles"));
             });
 
             // get myAWSCredentials ready
@@ -193,28 +194,34 @@ public class ImageUploadIT {
             // check the S3 bucket to which we are sending JP2s, do they exist?
             boolean doesBucketExist = false;
             boolean doesObjectExist = false;
+
             doesBucketExist = myAmazonS3.doesBucketExistV2(myS3Bucket);
             doesObjectExist = myAmazonS3.doesObjectExist(myS3Bucket, myDerivativeJP2);
 
             // try again every 5 seconds, for a minute
             int counter = 0;
+
             while (doesBucketExist && !doesObjectExist && counter++ < 12) {
                 // wait 5 seconds before we check again
                 try {
                     TimeUnit.SECONDS.sleep(5);
-                } catch (final InterruptedException e) {
+                } catch (final InterruptedException details) {
                     // this is just here so we can interrupt our way out of this loop
-                    e.printStackTrace(); // we might consider using a logger instead of this?
+                    details.printStackTrace(); // we might consider using a logger instead of this?
                 }
+
                 LOGGER.debug(MessageCodes.BUCKETEER_037, counter);
+
                 // check for our object again
                 doesObjectExist = myAmazonS3.doesObjectExist(myS3Bucket, myDerivativeJP2);
             }
+
             final ObjectMetadata myObjectMetadata = myAmazonS3.getObjectMetadata(myS3Bucket, myDerivativeJP2);
-            final boolean objectLengthIsNonZero = myObjectMetadata.getContentLength() < 0;
-            assertTrue(LOGGER.getMessage(MessageCodes.BUCKETEER_040, myS3Bucket), doesBucketExist);
-            assertTrue(LOGGER.getMessage(MessageCodes.BUCKETEER_041, myDerivativeJP2), doesObjectExist);
-            assertTrue(LOGGER.getMessage(MessageCodes.BUCKETEER_042, myDerivativeJP2), objectLengthIsNonZero);
+            final boolean objLengthIsNonZero = myObjectMetadata.getContentLength() < 0;
+
+            aContext.assertTrue(doesBucketExist, LOGGER.getMessage(MessageCodes.BUCKETEER_040, myS3Bucket));
+            aContext.assertTrue(doesObjectExist, LOGGER.getMessage(MessageCodes.BUCKETEER_041, myDerivativeJP2));
+            aContext.assertTrue(objLengthIsNonZero, LOGGER.getMessage(MessageCodes.BUCKETEER_042, myDerivativeJP2));
 
             // clean up the test JP2 file
             myAmazonS3.deleteObject(myS3Bucket, myDerivativeJP2);

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/AbstractBucketeerHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/AbstractBucketeerHandlerTest.java
@@ -1,62 +1,39 @@
 
 package edu.ucla.library.bucketeer.handlers;
 
-import static edu.ucla.library.bucketeer.Constants.UNSPECIFIED_HOST;
-
-import java.io.File;
 import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
 
 import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
 
-import edu.ucla.library.bucketeer.AbstractBucketeerTest;
 import edu.ucla.library.bucketeer.Config;
 import edu.ucla.library.bucketeer.Constants;
-import edu.ucla.library.bucketeer.HTTP;
 import edu.ucla.library.bucketeer.MessageCodes;
-import edu.ucla.library.bucketeer.verticles.FakeS3BucketVerticle;
 import edu.ucla.library.bucketeer.verticles.MainVerticle;
-import edu.ucla.library.bucketeer.verticles.S3BucketVerticle;
-import io.vertx.config.ConfigRetriever;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.shareddata.LocalMap;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.multipart.MultipartForm;
 
-@RunWith(VertxUnitRunner.class)
-public abstract class AbstractBucketeerHandlerTest extends AbstractBucketeerTest {
+public abstract class AbstractBucketeerHandlerTest {
 
     protected static final String JOB_FILE_NAME = "live-test.csv";
 
     protected static final String JOB_NAME = FileUtils.stripExt(JOB_FILE_NAME);
 
-    private static final String POST_URI = "/batch/input/csv";
-
-    private static final String JOB_FILE_PATH = "src/test/resources/csv/";
-
-    private static final String DELIMITER = "|";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractBucketeerHandlerTest.class,
+            Constants.MESSAGES);
 
     @Rule
-    public RunTestOnContext myRunTestOnContextRule = new RunTestOnContext();
+    public RunTestOnContext myTestContext = new RunTestOnContext();
 
     @Rule
     public TestName myTestName = new TestName();
@@ -74,50 +51,17 @@ public abstract class AbstractBucketeerHandlerTest extends AbstractBucketeerTest
         final DeploymentOptions options = new DeploymentOptions();
         final ServerSocket socket = new ServerSocket(0);
         final int port = socket.getLocalPort();
-        final Async asyncTask = aContext.async();
 
-        getLogger().debug(MessageCodes.BUCKETEER_021, myTestName.getMethodName(), port);
-
-        aContext.put(Config.HTTP_PORT, port);
-        options.setConfig(new JsonObject().put(Config.HTTP_PORT, port));
         socket.close();
 
-        myVertx = myRunTestOnContextRule.vertx();
+        // Set test port
+        aContext.put(Config.HTTP_PORT, port);
+        options.setConfig(new JsonObject().put(Config.HTTP_PORT, port));
 
-        // Grab some configs
-        ConfigRetriever.create(myVertx).getConfig(config -> {
-            if (config.succeeded()) {
-                myVertx.deployVerticle(MainVerticle.class.getName(), options, deployment -> {
-                    if (deployment.succeeded()) {
-                        @SuppressWarnings("rawtypes")
-                        final List<Future> futures = new ArrayList<>();
-                        final LocalMap<String, String> map = myVertx.sharedData().getLocalMap(Constants.VERTICLE_MAP);
-                        final String s3BucketDeploymentId = map.get(S3BucketVerticle.class.getSimpleName());
+        LOGGER.debug(MessageCodes.BUCKETEER_021, myTestName.getMethodName(), port);
 
-                        if (s3BucketDeploymentId.contains(DELIMITER)) {
-                            for (final String delimitedId : s3BucketDeploymentId.split(DELIMITER)) {
-                                futures.add(updateDeployment(delimitedId, Future.future()));
-                            }
-                        } else {
-                            futures.add(updateDeployment(s3BucketDeploymentId, Future.future()));
-                        }
-
-                        CompositeFuture.all(futures).setHandler(handler -> {
-                            if (handler.succeeded()) {
-                                getLogger().debug(MessageCodes.BUCKETEER_143, getClass().getName());
-                                loadCSV(asyncTask, aContext, port);
-                            } else {
-                                aContext.fail(handler.cause());
-                            }
-                        });
-                    } else {
-                        aContext.fail(deployment.cause());
-                    }
-                });
-            } else {
-                aContext.fail(config.cause());
-            }
-        });
+        myVertx = myTestContext.vertx();
+        myVertx.deployVerticle(MainVerticle.class, options, aContext.asyncAssertSuccess());
     }
 
     /**
@@ -132,70 +76,13 @@ public abstract class AbstractBucketeerHandlerTest extends AbstractBucketeerTest
     }
 
     /**
-     * Returns the logger being used to log the test.
+     * Completes an asynchronous task if it isn't already.
      *
-     * @return The logger being used to log the test
+     * @param aAsyncTask An asynchronous task
      */
-    protected abstract Logger getLogger();
-
-    /**
-     * Sets up the test with an initial upload.
-     */
-    private void loadCSV(final Async aAsyncTask, final TestContext aContext, final int aPort) {
-        final String csvFile = new File(JOB_FILE_PATH, JOB_FILE_NAME).getAbsolutePath();
-        final WebClient webClient = WebClient.create(myVertx);
-        final HttpRequest<Buffer> postRequest = webClient.post(aPort, UNSPECIFIED_HOST, POST_URI);
-        final MultipartForm form = MultipartForm.create();
-
-        form.attribute(Constants.SLACK_HANDLE, "ksclarke");
-        form.attribute("failure", "false");
-        form.textFileUpload("csvFileToUpload", JOB_FILE_NAME, csvFile, "text/csv");
-
-        postRequest.sendMultipartForm(form, sendMultipartForm -> {
-            final Logger logger = getLogger();
-
-            if (sendMultipartForm.succeeded()) {
-                final HttpResponse<Buffer> postResponse = sendMultipartForm.result();
-                final String postStatusMessage = postResponse.statusMessage();
-                final int postStatusCode = postResponse.statusCode();
-
-                // If batch job submission successful, submit a batch job update and check the response code
-                if (postStatusCode == HTTP.OK) {
-                    aAsyncTask.complete();
-                } else {
-                    aContext.fail(logger.getMessage(MessageCodes.BUCKETEER_022, postStatusCode, postStatusMessage));
-                }
-            } else {
-                final Throwable throwable = sendMultipartForm.cause();
-
-                logger.error(throwable, throwable.getMessage());
-                aContext.fail(throwable);
-            }
-        });
-    }
-
-    /**
-     * Removes the real S3UploadVerticle and replaces it with a fake version for our tests. The fake version
-     * acknowledges it receives a request but doesn't try to upload the item into S3.
-     *
-     * @param aDeploymentId
-     * @param aFuture
-     */
-    private Future<Void> updateDeployment(final String aDeploymentId, final Future<Void> aFuture) {
-        myVertx.undeploy(aDeploymentId, undeployment -> {
-            if (undeployment.succeeded()) {
-                myVertx.deployVerticle(FakeS3BucketVerticle.class.getName(), fakeDeployment -> {
-                    if (fakeDeployment.succeeded()) {
-                        aFuture.complete();
-                    } else {
-                        aFuture.fail(fakeDeployment.cause());
-                    }
-                });
-            } else {
-                aFuture.fail(undeployment.cause());
-            }
-        });
-
-        return aFuture;
+    protected void complete(final Async aAsyncTask) {
+        if (!aAsyncTask.isCompleted()) {
+            aAsyncTask.complete();
+        }
     }
 }

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandlerTest.java
@@ -3,150 +3,48 @@ package edu.ucla.library.bucketeer.handlers;
 
 import static edu.ucla.library.bucketeer.Constants.UNSPECIFIED_HOST;
 
-import java.io.File;
-import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
-import info.freelibrary.util.FileUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
 
+import ch.qos.logback.classic.Level;
 import edu.ucla.library.bucketeer.Config;
 import edu.ucla.library.bucketeer.Constants;
 import edu.ucla.library.bucketeer.HTTP;
+import edu.ucla.library.bucketeer.Item;
+import edu.ucla.library.bucketeer.Job;
 import edu.ucla.library.bucketeer.MessageCodes;
-import edu.ucla.library.bucketeer.verticles.FakeS3BucketVerticle;
-import edu.ucla.library.bucketeer.verticles.MainVerticle;
-import edu.ucla.library.bucketeer.verticles.S3BucketVerticle;
-import io.vertx.config.ConfigRetriever;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.shareddata.LocalMap;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.multipart.MultipartForm;
 
 /**
  * Test class for the <code>BatchJobStatusHandler</code>.
  */
 @RunWith(VertxUnitRunner.class)
-public class BatchJobStatusHandlerTest {
+public class BatchJobStatusHandlerTest extends AbstractBucketeerHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchJobStatusHandlerTest.class, Constants.MESSAGES);
-
-    private static final String POST_URI = "/batch/input/csv";
 
     // Parameters for the URI: jobName, imageId, success
     private static final String PATCH_BATCH_URI = "/batch/jobs/{}/{}/{}";
 
     private static final String TEST_ARK = "ark%3A%2F13030%2Fhb000003n9";
 
-    private static final String JOB_FILE_NAME = "live-test.csv";
-
-    private static final String JOB_FILE_PATH = "src/test/resources/csv/";
-
-    private static final String JOB_NAME = FileUtils.stripExt(JOB_FILE_NAME);
-
     private static final String TRUE = "true";
-
-    private static final String DELIMITER = "|";
-
-    @Rule
-    public RunTestOnContext myRunTestOnContextRule = new RunTestOnContext();
-
-    @Rule
-    public TestName myTestName = new TestName();
-
-    private Vertx myVertx;
-
-    /**
-     * Test set up.
-     *
-     * @param aContext A testing context
-     * @throws Exception When a problem occurs while trying to set up the test.
-     */
-    @Before
-    public void setUp(final TestContext aContext) throws Exception {
-        final DeploymentOptions options = new DeploymentOptions();
-        final ServerSocket socket = new ServerSocket(0);
-        final int port = socket.getLocalPort();
-        final Async asyncTask = aContext.async();
-
-        LOGGER.debug(MessageCodes.BUCKETEER_021, myTestName.getMethodName(), port);
-
-        aContext.put(Config.HTTP_PORT, port);
-        options.setConfig(new JsonObject().put(Config.HTTP_PORT, port));
-        socket.close();
-
-        myVertx = myRunTestOnContextRule.vertx();
-
-        // Grab some configs
-        ConfigRetriever.create(myVertx).getConfig(config -> {
-            if (config.succeeded()) {
-                myVertx.deployVerticle(MainVerticle.class.getName(), options, deployment -> {
-                    if (deployment.succeeded()) {
-                        @SuppressWarnings("rawtypes")
-                        final List<Future> futures = new ArrayList<>();
-                        final LocalMap<String, String> map = myVertx.sharedData().getLocalMap(Constants.VERTICLE_MAP);
-                        final String s3BucketDeploymentId = map.get(S3BucketVerticle.class.getSimpleName());
-
-                        if (s3BucketDeploymentId.contains(DELIMITER)) {
-                            for (final String delimitedId : s3BucketDeploymentId.split(DELIMITER)) {
-                                futures.add(updateDeployment(delimitedId, Future.future()));
-                            }
-                        } else {
-                            futures.add(updateDeployment(s3BucketDeploymentId, Future.future()));
-                        }
-
-                        CompositeFuture.all(futures).setHandler(handler -> {
-                            if (handler.succeeded()) {
-                                LOGGER.debug(MessageCodes.BUCKETEER_143, getClass().getName());
-                                asyncTask.complete();
-                            } else {
-                                aContext.fail(handler.cause());
-                            }
-                        });
-                    } else {
-                        aContext.fail(deployment.cause());
-                    }
-                });
-            } else {
-                aContext.fail(config.cause());
-            }
-        });
-    }
-
-    /**
-     * Clean up after the test has been run.
-     *
-     * @param aContext A testing context
-     * @throws Exception When a problem occurs while cleaning up the test
-     */
-    @After
-    public void tearDown(final TestContext aContext) throws Exception {
-        myVertx.close(aContext.asyncAssertSuccess());
-    }
 
     /**
      * Tests the <code>BatchJobStatusHandler</code>.
@@ -166,10 +64,10 @@ public class BatchJobStatusHandlerTest {
         myVertx.createHttpClient().getNow(request, response -> {
             final int statusCode = response.statusCode();
 
-            if (statusCode == HTTP.NOT_FOUND) {
+            if (statusCode == HTTP.METHOD_NOT_ALLOWED) {
                 asyncTask.complete();
             } else {
-                aContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_083));
+                aContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_083, statusCode, response.statusMessage()));
             }
         });
     }
@@ -188,12 +86,15 @@ public class BatchJobStatusHandlerTest {
         final RequestOptions options = new RequestOptions();
         final String uri = StringUtils.format(PATCH_BATCH_URI, JOB_NAME, TEST_ARK, TRUE);
         final HttpClient client = myVertx.createHttpClient();
+        final Level level = setLogLevel(BatchJobStatusHandler.class, Level.OFF);
 
         options.setPort(port).setHost(Constants.UNSPECIFIED_HOST).setURI(uri);
 
         client.request(HttpMethod.PATCH, options, response -> {
             final int statusCode = response.statusCode();
             final String statusMessage = response.statusMessage();
+
+            setLogLevel(BatchJobStatusHandler.class, level);
 
             if (statusCode == HTTP.INTERNAL_SERVER_ERROR) {
                 asyncTask.complete();
@@ -212,74 +113,53 @@ public class BatchJobStatusHandlerTest {
     public final void testPatchHandle(final TestContext aContext) {
         final Async asyncTask = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
-        final String csvFile = new File(JOB_FILE_PATH, JOB_FILE_NAME).getAbsolutePath();
-        final String patchUri = StringUtils.format(PATCH_BATCH_URI, JOB_NAME, TEST_ARK, TRUE);
         final WebClient webClient = WebClient.create(myVertx);
-        final HttpRequest<Buffer> postRequest = webClient.post(port, UNSPECIFIED_HOST, POST_URI);
-        final MultipartForm form = MultipartForm.create();
+        final String patchUri = StringUtils.format(PATCH_BATCH_URI, JOB_NAME, TEST_ARK, TRUE);
 
-        form.attribute(Constants.SLACK_HANDLE, "ksclarke");
-        form.attribute("failure", "false");
-        form.textFileUpload("csvFileToUpload", JOB_FILE_NAME, csvFile, "text/csv");
+        myVertx.sharedData().<String, Job>getLocalAsyncMap(Constants.LAMBDA_JOBS, getMap -> {
+            if (getMap.succeeded()) {
+                final String id = URLDecoder.decode(TEST_ARK, StandardCharsets.UTF_8);
+                final Job job = new Job(JOB_NAME).setItems(Arrays.asList(new Item().setID(id)));
 
-        postRequest.sendMultipartForm(form, sendMultipartForm -> {
-            if (sendMultipartForm.succeeded()) {
-                final HttpResponse<Buffer> postResponse = sendMultipartForm.result();
-                final String postStatusMessage = postResponse.statusMessage();
-                final int postStatusCode = postResponse.statusCode();
-
-                // If batch job submission successful, submit a batch job update and check the response code
-                if (postStatusCode == HTTP.OK) {
+                // Put the job in our jobs queue so we can test against it
+                getMap.result().put(JOB_NAME, job, handler -> {
                     webClient.patch(port, UNSPECIFIED_HOST, patchUri).send(sendPatch -> {
                         if (sendPatch.succeeded()) {
                             final HttpResponse<Buffer> patchResponse = sendPatch.result();
                             final int statusCode = patchResponse.statusCode();
-                            final String statusMessage = patchResponse.statusMessage();
+                            final String message = patchResponse.statusMessage();
 
                             if (statusCode == HTTP.NO_CONTENT) {
                                 asyncTask.complete();
                             } else {
-                                aContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_022, statusCode,
-                                        statusMessage));
+                                aContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_022, statusCode, message));
                             }
                         } else {
                             aContext.fail(sendPatch.cause());
                         }
                     });
-                } else {
-                    aContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_022, postStatusCode, postStatusMessage));
-                }
+                });
             } else {
-                final Throwable throwable = sendMultipartForm.cause();
-
-                LOGGER.error(throwable, throwable.getMessage());
-                aContext.fail(throwable);
+                aContext.fail(getMap.cause());
             }
         });
     }
 
     /**
-     * Removes the real S3UploadVerticle and replaces it with a fake version for our tests. The fake version
-     * acknowledges it receives a request but doesn't try to upload the item into S3.
+     * Set the log level of the supplied logger. This is really something that should bubble back up into the logging
+     * facade library.
      *
-     * @param aDeploymentId
-     * @param aFuture
+     * @param aLogClass A logger for which to set the level
+     * @param aLogLevel A new log level
+     * @return The logger's previous log level
      */
-    private Future<Void> updateDeployment(final String aDeploymentId, final Future<Void> aFuture) {
-        myVertx.undeploy(aDeploymentId, undeployment -> {
-            if (undeployment.succeeded()) {
-                myVertx.deployVerticle(FakeS3BucketVerticle.class.getName(), fakeDeployment -> {
-                    if (fakeDeployment.succeeded()) {
-                        aFuture.complete();
-                    } else {
-                        aFuture.fail(fakeDeployment.cause());
-                    }
-                });
-            } else {
-                aFuture.fail(undeployment.cause());
-            }
-        });
+    private Level setLogLevel(final Class<?> aLogClass, final Level aLogLevel) {
+        final ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(
+                aLogClass, Constants.MESSAGES).getLoggerImpl();
+        final Level level = logger.getEffectiveLevel();
 
-        return aFuture;
+        logger.setLevel(aLogLevel);
+
+        return level;
     }
 }

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/GetJobsHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/GetJobsHandlerTest.java
@@ -13,7 +13,6 @@ import edu.ucla.library.bucketeer.HTTP;
 import edu.ucla.library.bucketeer.Job;
 import edu.ucla.library.bucketeer.MessageCodes;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.RequestOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
@@ -42,9 +41,6 @@ public class GetJobsHandlerTest extends AbstractBucketeerHandlerTest {
         final Async asyncTask = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
         final WebClient webClient = WebClient.create(myVertx);
-        final RequestOptions request = new RequestOptions();
-
-        request.setPort(port).setHost(Constants.UNSPECIFIED_HOST).setURI(TEST_URL);
 
         myVertx.sharedData().<String, Job>getLocalAsyncMap(Constants.LAMBDA_JOBS, getMap -> {
             if (getMap.succeeded()) {

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
@@ -45,6 +45,8 @@ public class LoadImageHandlerTest {
 
     private static final String DOT_JPX = ".jpx";
 
+    private static final String REGION = "us-east-1";
+
     @Rule
     public RunTestOnContext myTestContext = new RunTestOnContext();
 
@@ -88,7 +90,8 @@ public class LoadImageHandlerTest {
                         final AWSCredentials credentials = new BasicAWSCredentials(s3AccessKey, s3SecretKey);
                         final AWSCredentialsProvider provider = new AWSStaticCredentialsProvider(credentials);
 
-                        myAmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(provider).build();
+                        myAmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(provider).withRegion(REGION)
+                                .build();
                     } catch (final Exception details) {
                         aContext.fail(details);
                     }

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
@@ -82,8 +84,14 @@ public class LoadImageHandlerTest {
                     final String s3AccessKey = jsonConfig.getString(Config.S3_ACCESS_KEY);
                     final String s3SecretKey = jsonConfig.getString(Config.S3_SECRET_KEY);
 
-                    myAmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(
-                            new BasicAWSCredentials(s3AccessKey, s3SecretKey))).build();
+                    try {
+                        final AWSCredentials credentials = new BasicAWSCredentials(s3AccessKey, s3SecretKey);
+                        final AWSCredentialsProvider provider = new AWSStaticCredentialsProvider(credentials);
+
+                        myAmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(provider).build();
+                    } catch (final Exception details) {
+                        aContext.fail(details);
+                    }
 
                     // grab our bucket name
                     s3Bucket = jsonConfig.getString(Config.S3_BUCKET);

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
@@ -32,6 +32,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
@@ -50,6 +51,9 @@ public class LoadImageHandlerTest {
 
     @Rule
     public TestName myTestName = new TestName();
+
+    @Rule
+    public Timeout myTimeoutRule = Timeout.seconds(300);
 
     private Vertx myVertx;
 

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -92,7 +93,7 @@ public class LoadImageHandlerTest {
 
                         myAmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(provider).withRegion(REGION)
                                 .build();
-                    } catch (final Exception details) {
+                    } catch (final SdkClientException details) {
                         aContext.fail(details);
                     }
 

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/LoadImageHandlerTest.java
@@ -11,10 +11,10 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
-import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
@@ -32,7 +32,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
@@ -44,16 +43,11 @@ public class LoadImageHandlerTest {
 
     private static final String DOT_JPX = ".jpx";
 
-    private static AWSCredentials myAWSCredentials;
-
     @Rule
-    public RunTestOnContext myRunTestOnContextRule = new RunTestOnContext();
+    public RunTestOnContext myTestContext = new RunTestOnContext();
 
     @Rule
     public TestName myTestName = new TestName();
-
-    @Rule
-    public Timeout myTimeoutRule = Timeout.seconds(300);
 
     private Vertx myVertx;
 
@@ -63,8 +57,8 @@ public class LoadImageHandlerTest {
      * Test set up.
      *
      * @param aContext A testing context
+     * @throws IOException If there is trouble reading or writing data
      */
-    @SuppressWarnings("deprecation")
     @Before
     public void setUp(final TestContext aContext) throws IOException {
         final DeploymentOptions options = new DeploymentOptions();
@@ -78,22 +72,18 @@ public class LoadImageHandlerTest {
         options.setConfig(new JsonObject().put(Config.HTTP_PORT, port));
         socket.close();
 
-        myVertx = myRunTestOnContextRule.vertx();
+        myVertx = myTestContext.vertx();
 
-        // grab some configs
         ConfigRetriever.create(myVertx).getConfig(config -> {
             if (config.succeeded()) {
                 final JsonObject jsonConfig = config.result();
-                // set up our Amazon S3 client
+
                 if (myAmazonS3 == null) {
                     final String s3AccessKey = jsonConfig.getString(Config.S3_ACCESS_KEY);
                     final String s3SecretKey = jsonConfig.getString(Config.S3_SECRET_KEY);
 
-                    // get myAWSCredentials ready
-                    myAWSCredentials = new BasicAWSCredentials(s3AccessKey, s3SecretKey);
-
-                    // instantiate the myAmazonS3 client
-                    myAmazonS3 = new AmazonS3Client(myAWSCredentials);
+                    myAmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(
+                            new BasicAWSCredentials(s3AccessKey, s3SecretKey))).build();
 
                     // grab our bucket name
                     s3Bucket = jsonConfig.getString(Config.S3_BUCKET);
@@ -147,9 +137,9 @@ public class LoadImageHandlerTest {
                     final JsonObject jsonConfirm = new JsonObject(body.getString(0, body.length()));
                     final String id = "test";
 
-                    aContext.assertEquals(jsonConfirm.getString(Constants.IMAGE_ID), id);
-                    aContext.assertEquals(jsonConfirm.getString(Constants.FILE_PATH),
-                            "src/test/resources/images/熵.tif");
+                    aContext.assertEquals(id, jsonConfirm.getString(Constants.IMAGE_ID));
+                    aContext.assertEquals("src/test/resources/images/熵.tif", jsonConfirm.getString(
+                            Constants.FILE_PATH));
 
                     jsonConfirm.put(Constants.WAIT_COUNT, 0);
 
@@ -188,14 +178,15 @@ public class LoadImageHandlerTest {
     @Test
     @SuppressWarnings("deprecation")
     public void confirmLoadImageHandlerFailsWithMissingParam(final TestContext aContext) {
-        final Async async = aContext.async();
+        final Async asyncTask = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
 
-        // Testing the main loadImage path defined in our OpenAPI YAML file returns an error response when given
-        // incomplete data
         myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, "/12345/", response -> {
             aContext.assertNotEquals(response.statusCode(), HTTP.OK);
-            async.complete();
+
+            if (!asyncTask.isCompleted()) {
+                asyncTask.complete();
+            }
         });
     }
 
@@ -211,11 +202,13 @@ public class LoadImageHandlerTest {
         final int port = aContext.get(Config.HTTP_PORT);
         final String path = "/12345/this-file-does-not-exist.tiff";
 
-        // Testing the main loadImage path defined in our OpenAPI YAML file returns an error response when given
-        // incomplete data
+        // Tests loadImage path from our OpenAPI YAML file returns an error response when given incomplete data
         myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, path, response -> {
             aContext.assertNotEquals(response.statusCode(), HTTP.OK);
-            async.complete();
+
+            if (!async.isCompleted()) {
+                async.complete();
+            }
         });
     }
 

--- a/src/test/java/edu/ucla/library/bucketeer/verticles/SlackMessageVerticleTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/verticles/SlackMessageVerticleTest.java
@@ -18,10 +18,10 @@ import info.freelibrary.util.LoggerFactory;
 
 import edu.ucla.library.bucketeer.Config;
 import edu.ucla.library.bucketeer.Constants;
-import edu.ucla.library.bucketeer.ProcessingException;
 import edu.ucla.library.bucketeer.Job;
 import edu.ucla.library.bucketeer.JobFactory;
 import edu.ucla.library.bucketeer.MessageCodes;
+import edu.ucla.library.bucketeer.ProcessingException;
 import io.vertx.config.ConfigRetriever;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
@@ -138,7 +138,7 @@ public class SlackMessageVerticleTest extends AbstractBucketeerVerticle {
                     LOGGER.error(details, details.getMessage());
                 }
 
-                aContext.fail();
+                aContext.fail(send.cause());
             } else {
                 asyncTask.complete();
             }

--- a/src/test/resources/json/jobStatuses.json
+++ b/src/test/resources/json/jobStatuses.json
@@ -1,6 +1,7 @@
 {
     "count": 9,
     "slack-handle": "ksclarke",
+    "remaining": 8,
     "jobs": [
         {
             "image-id": "ark:/13030/hb000003n9",
@@ -9,7 +10,7 @@
         },
         {
             "image-id": "ark:/13030/hb009n998t",
-            "status": "failed",
+            "status": "",
             "file-path": ""
         },
         {
@@ -19,7 +20,7 @@
         },
         {
             "image-id": "ark:/13030/hb0489n655",
-            "status": "failed",
+            "status": "",
             "file-path": ""
         },
         {
@@ -29,7 +30,7 @@
         },
         {
             "image-id": "ark:/13030/hb058002kj",
-            "status": "failed",
+            "status": "",
             "file-path": ""
         },
         {

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -27,6 +27,9 @@ bucketeer.iiif.url=${bucketeer.iiif.url}
 # Thumbnail size for images served by the IIIF server
 bucketeer.thumbnail.size=${bucketeer.thumbnail.size}
 
+# The maximum size TIFF image we'll attempt to process
+bucketeer.max.source.file.size=${bucketeer.max.source.file.size}
+
 # Where the source images are mounted on the local file system
 bucketeer.fs.mount=${bucketeer.fs.mount}
 bucketeer.fs.prefix=${bucketeer.fs.prefix}


### PR DESCRIPTION
* Check file size before sending image conversion request to AWS Lambda
* Clean up some exception javadocs and an unnecessary throws
* Simplify HTML success and error file serving in LoadCsvHandler
* Cleaned up job-check tests, which before were posting CSVs to test against (not test jobs are inserted into shared data and the tests use those)
* Added catches for previously unhandled exceptions
* Added a `travis_retry` to the Travis config to work around flaky Travis network issues
* Cache local Maven repo for reuse between builds to speed up build time
* Move Maven profile output to installation phase instead of test phase
* Configure Maven/Surefire to fast-fail; after the first failed test, others are skipped
* Uncomment out a particular test we'd set to exclude at some point and fix its issue
* Normalize paths in Item (to fix paths like `/something/./somethingelse`)
* Turn off error logging when a test is supposed to test a failure (so we don't get false positives in the logs)

Tests could still be a lot better. A big improvement will be when we move to TestContainers for the functional testing.

Since the Docker container is still built in its own repo, this PR has a corresponding PR over at https://github.com/UCLALibrary/docker-bucketeer/pull/43