### PR TITLE
[IIIF-935] Fix NullPointerException in GetJobStatusesHandlerTest

### DIFF
--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -178,4 +178,5 @@
   <entry key="BUCKETEER-505">Incorrect media type; expected: application/json, found: {}</entry>
   <entry key="BUCKETEER-506">The main verticle was started, but the port ({}) is not ready!</entry>
   <entry key="BUCKETEER-507">Fester request for '{}' failed to be sent: {}</entry>
+  <entry key="BUCKETEER-508">GET in GetJobStatusesHandlerTest failed: {}</entry>
 </properties>

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandlerTest.java
@@ -141,27 +141,29 @@ public class GetJobStatusesHandlerTest extends AbstractBucketeerHandlerTest {
 
             if (aEvent.succeeded()) {
                 webClient.get(port, Constants.UNSPECIFIED_HOST, TEST_URL).send(get -> {
-                    final HttpResponse<Buffer> response = get.result();
-                    final int statusCode = response.statusCode();
-                    final String message = response.statusMessage();
+                    if (get.succeeded()) {
+                        final HttpResponse<Buffer> response = get.result();
+                        final int statusCode = response.statusCode();
+                        final String message = response.statusMessage();
 
-                    if (response.statusCode() == HTTP.OK) {
-                        // Update file paths to match the absolute paths on the machine that's running the test
-                        for (int index = 0; index < myJob.size(); index++) {
-                            if (index != 7) {
-                                myJob.getJsonObject(index).put(Constants.FILE_PATH, FILE_PATH.getAbsolutePath());
-                            } else {
-                                myJob.getJsonObject(index).put(Constants.FILE_PATH, FAIL_PATH.getAbsolutePath());
+                        if (response.statusCode() == HTTP.OK) {
+                            // Update file paths to match the absolute paths on the machine that's running the test
+                            for (int index = 0; index < myJob.size(); index++) {
+                                if (index != 7) {
+                                    myJob.getJsonObject(index).put(Constants.FILE_PATH, FILE_PATH.getAbsolutePath());
+                                } else {
+                                    myJob.getJsonObject(index).put(Constants.FILE_PATH, FAIL_PATH.getAbsolutePath());
+                                }
                             }
-                        }
 
-                        myContext.assertEquals(myExpectedObj, response.bodyAsJsonObject());
+                            myContext.assertEquals(myExpectedObj, response.bodyAsJsonObject());
 
-                        if (!myAsyncTask.isCompleted()) {
-                            myAsyncTask.complete();
+                            if (!myAsyncTask.isCompleted()) {
+                                myAsyncTask.complete();
+                            }
+                        } else {
+                            myContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_114, statusCode, message));
                         }
-                    } else {
-                        myContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_114, statusCode, message));
                     }
                 });
             } else {

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandlerTest.java
@@ -164,6 +164,8 @@ public class GetJobStatusesHandlerTest extends AbstractBucketeerHandlerTest {
                         } else {
                             myContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_114, statusCode, message));
                         }
+                    } else {
+                        myContext.fail(LOGGER.getMessage(MessageCodes.BUCKETEER_508, get.cause().getMessage()));
                     }
                 });
             } else {


### PR DESCRIPTION
Updated test to verify successful GET response before attempting to use response contents
* Modified GetJobStatusesHandlerTest.java to verify successful GET request
* Added entry in bucketeer_messages.xml for failed GET in GetJobStatusesHandlerTest