### PR TITLE
Release 0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>bucketeer</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.2-SNAPSHOT</version>
   <name>Bucketeer</name>
   <description>A TIFF to JP2 to S3 bucket microservice</description>
   <url>https://github.com/uclalibrary/bucketeer</url>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <!-- Git repo with Kakadu source code (ours is private; override with yours) -->
     <kakadu.git.repo>scm:git:git@github.com:uclalibrary/kakadu.git</kakadu.git.repo>
 
-    <vertx.version>3.9.1</vertx.version>
+    <vertx.version>3.9.4</vertx.version>
     <vertx.super.s3.version>1.2.0</vertx.super.s3.version>
     <slf4j.ext.version>1.7.26</slf4j.ext.version>
     <aws.sdk.version>1.11.846</aws.sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <moirai.version>2.0.0</moirai.version>
     <beanutils.version>1.9.4</beanutils.version>
     <woodstox.version>5.1.0</woodstox.version>
-    <freelib.utils.version>1.1.0</freelib.utils.version>
+    <freelib.utils.version>2.1.0</freelib.utils.version>
     <freelib.maven.version>0.1.0</freelib.maven.version>
     <netty.epoll.version>4.1.37.Final</netty.epoll.version>
     <maven.failsafe.plugin.version>2.18.1</maven.failsafe.plugin.version>
@@ -361,6 +361,12 @@
       <testResource>
         <directory>src/test/resources</directory>
         <filtering>true</filtering>
+        <excludes>
+          <!-- We don't need to filter binary files -->
+          <exclude>images/*.tif</exclude>
+          <exclude>images/*.jpx</exclude>
+          <exclude>*.enc</exclude>
+        </excludes>
       </testResource>
     </testResources>
 
@@ -976,6 +982,7 @@
                   <exclude>io.vertx:vertx-web</exclude>
                   <exclude>jakarta.activation:jakarta.activation-api</exclude>
                   <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                  <exclude>jakarta.validation:jakarta.validation-api</exclude>
                   <exclude>javax.activation:activation</exclude>
                   <exclude>javax.annotation:jsr250-api</exclude>
                   <exclude>javax.enterprise:cdi-api</exclude>
@@ -1020,6 +1027,8 @@
                   <exclude>org.glassfish:javax.json</exclude>
                   <exclude>org.jboss.forge.roaster:roaster-api</exclude>
                   <exclude>org.jboss.forge.roaster:roaster-jdt</exclude>
+                  <exclude>org.jruby.jcodings:jcodings</exclude>
+                  <exclude>org.jruby.joni:joni</exclude>
                   <exclude>org.mozilla:rhino</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>
                   <exclude>org.slf4j:slf4j-ext</exclude>
@@ -1322,7 +1331,7 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>4.0.1</version>
+    <version>5.2.0</version>
   </parent>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1045,6 +1045,12 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- Sets the prepare_release scripts to be executable -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>bucketeer</artifactId>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.2.1</version>
   <name>Bucketeer</name>
   <description>A TIFF to JP2 to S3 bucket microservice</description>
   <url>https://github.com/uclalibrary/bucketeer</url>

--- a/src/main/java/edu/ucla/library/bucketeer/converters/Converter.java
+++ b/src/main/java/edu/ucla/library/bucketeer/converters/Converter.java
@@ -4,6 +4,9 @@ package edu.ucla.library.bucketeer.converters;
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * An interface for implementations that convert TIFFs into JP2s.
+ */
 public interface Converter {
 
     /**

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
@@ -35,6 +35,9 @@ import io.vertx.core.shareddata.Lock;
 import io.vertx.core.shareddata.SharedData;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * A handler for batch job status requests.
+ */
 public class BatchJobStatusHandler extends AbstractBucketeerHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchJobStatusHandler.class, Constants.MESSAGES);

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/FailureHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/FailureHandler.java
@@ -21,6 +21,9 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.validation.ValidationException;
 
+/**
+ * A handler for failures not automatically handled by the OpenAPI routing.
+ */
 public final class FailureHandler implements Handler<RoutingContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FailureHandler.class, MESSAGES);

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/LoadCsvHandler.java
@@ -51,6 +51,9 @@ import io.vertx.core.shareddata.SharedData;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * A handler of CSV ingest requests.
+ */
 public class LoadCsvHandler extends AbstractBucketeerHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoadCsvHandler.class, Constants.MESSAGES);

--- a/src/main/java/edu/ucla/library/bucketeer/utils/AnnotationMappingStrategy.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/AnnotationMappingStrategy.java
@@ -19,6 +19,11 @@ import info.freelibrary.util.StringUtils;
 import edu.ucla.library.bucketeer.Constants;
 import edu.ucla.library.bucketeer.MessageCodes;
 
+/**
+ * A strategy for handling CSV mapping annotations.
+ *
+ * @param <T> A type to be map to CSV format
+ */
 public class AnnotationMappingStrategy<T> extends HeaderColumnNameTranslateMappingStrategy<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationMappingStrategy.class, Constants.MESSAGES);

--- a/src/main/java/edu/ucla/library/bucketeer/utils/AnnotationMappingStrategy.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/AnnotationMappingStrategy.java
@@ -22,7 +22,7 @@ import edu.ucla.library.bucketeer.MessageCodes;
 /**
  * A strategy for handling CSV mapping annotations.
  *
- * @param <T> A type to be map to CSV format
+ * @param <T> A type to be mapped to CSV format
  */
 public class AnnotationMappingStrategy<T> extends HeaderColumnNameTranslateMappingStrategy<T> {
 

--- a/src/main/java/edu/ucla/library/bucketeer/utils/GenericFilePathPrefix.java
+++ b/src/main/java/edu/ucla/library/bucketeer/utils/GenericFilePathPrefix.java
@@ -6,6 +6,9 @@ import java.io.File;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * A basic file path prefix implementation.
+ */
 public class GenericFilePathPrefix implements IFilePathPrefix {
 
     /**

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/AbstractBucketeerVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/AbstractBucketeerVerticle.java
@@ -14,6 +14,9 @@ import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.LocalMap;
 
+/**
+ * An abstract verticle that Bucketeer verticles can extend.
+ */
 public abstract class AbstractBucketeerVerticle extends AbstractVerticle {
 
     @Override

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/FesterVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/FesterVerticle.java
@@ -29,6 +29,9 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.multipart.MultipartForm;
 
+/**
+ * A verticle that sends Bucketeer CSV ingests to Fester. This is not currently in use.
+ */
 public class FesterVerticle extends AbstractBucketeerVerticle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FesterVerticle.class, Constants.MESSAGES);

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/FinalizeJobVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/FinalizeJobVerticle.java
@@ -22,6 +22,9 @@ import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.AsyncMap;
 
+/**
+ * A verticle to wrap-up batch jobs once they've been completed.
+ */
 public class FinalizeJobVerticle extends AbstractBucketeerVerticle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FinalizeJobVerticle.class, Constants.MESSAGES);

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/ImageWorkerVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/ImageWorkerVerticle.java
@@ -28,6 +28,9 @@ import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 
+/**
+ * A verticle that handles individual image conversion requests.
+ */
 public class ImageWorkerVerticle extends AbstractBucketeerVerticle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageWorkerVerticle.class, MESSAGES);

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/ItemFailureVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/ItemFailureVerticle.java
@@ -24,6 +24,9 @@ import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.core.shareddata.Lock;
 import io.vertx.core.shareddata.SharedData;
 
+/**
+ * A verticle that deals with image conversion failures.
+ */
 public class ItemFailureVerticle extends AbstractBucketeerVerticle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemFailureVerticle.class, Constants.MESSAGES);

--- a/src/main/tools/checkstyle/checkstyle.xml
+++ b/src/main/tools/checkstyle/checkstyle.xml
@@ -49,6 +49,8 @@
       <property name="scope" value="public" />
       <property name="allowUnknownTags" value="true" />
     </module>
+    <module name="MissingJavadocType"/>
+    <module name="MissingJavadocPackage"/>
     <module name="JavadocMethod">
       <property name="scope" value="public" />
     </module>

--- a/src/test/java/edu/ucla/library/bucketeer/CsvParsingExceptionTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/CsvParsingExceptionTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * A suite of tests related to CSV parsing exceptions.
+ */
 public class CsvParsingExceptionTest {
 
     private static final String EOL = System.lineSeparator();

--- a/src/test/java/edu/ucla/library/bucketeer/JobTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/JobTest.java
@@ -14,6 +14,9 @@ import info.freelibrary.util.StringUtils;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * A suite of batch job tests.
+ */
 public class JobTest extends AbstractBucketeerTest {
 
     private static final String TEST_JOB_NAME = "test-job";

--- a/src/test/java/edu/ucla/library/bucketeer/handlers/AbstractBucketeerHandlerTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/handlers/AbstractBucketeerHandlerTest.java
@@ -25,6 +25,9 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 
+/**
+ * Tests related to the shared methods in the abstract Bucketeer handler.
+ */
 public abstract class AbstractBucketeerHandlerTest {
 
     protected static final String JOB_FILE_NAME = "live-test.csv";

--- a/src/test/java/edu/ucla/library/bucketeer/utils/UCLAFilePathPrefixTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/utils/UCLAFilePathPrefixTest.java
@@ -7,6 +7,9 @@ import java.io.File;
 
 import org.junit.Test;
 
+/**
+ * Tests related to the UCLA file path prefix implementation.
+ */
 public class UCLAFilePathPrefixTest {
 
     private static final File DL_MASTERS_TEST_FILE = new File("asdf/aaaa");
@@ -20,8 +23,7 @@ public class UCLAFilePathPrefixTest {
      */
     @Test
     public final void testGetPrefixDlMasters() {
-        assertEquals("/mnt/ucla/Masters/dlmasters", new UCLAFilePathPrefix(ROOT_PATH).getPrefix(
-                DL_MASTERS_TEST_FILE));
+        assertEquals("/mnt/ucla/Masters/dlmasters", new UCLAFilePathPrefix(ROOT_PATH).getPrefix(DL_MASTERS_TEST_FILE));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/bucketeer/verticles/FakeS3BucketVerticle.java
+++ b/src/test/java/edu/ucla/library/bucketeer/verticles/FakeS3BucketVerticle.java
@@ -8,8 +8,12 @@ import info.freelibrary.util.LoggerFactory;
 
 import edu.ucla.library.bucketeer.MessageCodes;
 import edu.ucla.library.bucketeer.Op;
+
 import io.vertx.core.json.JsonObject;
 
+/**
+ * A verticle that helps test S3 interactions. This is slowly being replaced by the S3 LocalStack container.
+ */
 public class FakeS3BucketVerticle extends AbstractBucketeerVerticle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FakeS3BucketVerticle.class, MESSAGES);

--- a/src/test/java/edu/ucla/library/bucketeer/verticles/MainVerticleTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/verticles/MainVerticleTest.java
@@ -25,6 +25,9 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
+/**
+ * Tests of the main verticle that starts running when the application is started.
+ */
 @RunWith(VertxUnitRunner.class)
 public class MainVerticleTest {
 

--- a/src/test/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticleTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticleTest.java
@@ -24,6 +24,7 @@ import info.freelibrary.util.LoggerFactory;
 import edu.ucla.library.bucketeer.Config;
 import edu.ucla.library.bucketeer.Constants;
 import edu.ucla.library.bucketeer.MessageCodes;
+
 import io.vertx.config.ConfigRetriever;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
@@ -33,6 +34,9 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
+/**
+ * Tests of the verticle that sends JP2s to S3 buckets.
+ */
 @RunWith(VertxUnitRunner.class)
 public class S3BucketVerticleTest extends AbstractBucketeerVerticle {
 
@@ -79,8 +83,8 @@ public class S3BucketVerticleTest extends AbstractBucketeerVerticle {
                 myImageKey = UUID.randomUUID().toString() + ".jpx";
 
                 // We need to determine if we'll be able to run the S3 integration tests so we can skip if needed
-                if (config.containsKey(Config.S3_ACCESS_KEY) && !config.getString(Config.S3_ACCESS_KEY,
-                        DEFAULT_ACCESS_KEY).equalsIgnoreCase(DEFAULT_ACCESS_KEY)) {
+                if (config.containsKey(Config.S3_ACCESS_KEY) && !config
+                        .getString(Config.S3_ACCESS_KEY, DEFAULT_ACCESS_KEY).equalsIgnoreCase(DEFAULT_ACCESS_KEY)) {
                     isExecutable = true;
                 }
 

--- a/src/test/java/edu/ucla/library/bucketeer/verticles/SlackMessageVerticleTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/verticles/SlackMessageVerticleTest.java
@@ -22,6 +22,7 @@ import edu.ucla.library.bucketeer.Job;
 import edu.ucla.library.bucketeer.JobFactory;
 import edu.ucla.library.bucketeer.MessageCodes;
 import edu.ucla.library.bucketeer.ProcessingException;
+
 import io.vertx.config.ConfigRetriever;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
@@ -31,6 +32,9 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
+/**
+ * Tests of the Slack message verticle. This verticle sends Slack messages after batch jobs have been completed.
+ */
 @RunWith(VertxUnitRunner.class)
 public class SlackMessageVerticleTest extends AbstractBucketeerVerticle {
 
@@ -70,8 +74,8 @@ public class SlackMessageVerticleTest extends AbstractBucketeerVerticle {
             if (config.succeeded()) {
                 final JsonObject jsonConfig = config.result();
 
-                mySlackUserHandle = jsonConfig.getString(Config.SLACK_TEST_USER_HANDLE).replace(Constants.AT,
-                        Constants.EMPTY);
+                mySlackUserHandle =
+                        jsonConfig.getString(Config.SLACK_TEST_USER_HANDLE).replace(Constants.AT, Constants.EMPTY);
                 mySlackChannelID = jsonConfig.getString(Config.SLACK_CHANNEL_ID);
                 mySlackErrorChannelID = jsonConfig.getString(Config.SLACK_ERROR_CHANNEL_ID);
 
@@ -151,12 +155,12 @@ public class SlackMessageVerticleTest extends AbstractBucketeerVerticle {
      * @param aContext A test context
      */
     @Test
-    public final void testSlackFileUpload(final TestContext aContext) throws FileNotFoundException,
-            ProcessingException, IOException {
+    public final void testSlackFileUpload(final TestContext aContext)
+            throws FileNotFoundException, ProcessingException, IOException {
         final Job job = JobFactory.getInstance().createJob(TEST_JOB, LIVE_TEST_CSV);
         final String iiifURL = "unit.test.not.real.please.disregard.com";
-        final String slackMessage = LOGGER.getMessage(MessageCodes.BUCKETEER_111, mySlackUserHandle, job.size(),
-                iiifURL);
+        final String slackMessage =
+                LOGGER.getMessage(MessageCodes.BUCKETEER_111, mySlackUserHandle, job.size(), iiifURL);
         final Vertx vertx = myRunTestOnContextRule.vertx();
         final JsonObject message = new JsonObject();
         final Async asyncTask = aContext.async();


### PR DESCRIPTION
For release, I updated the vertx dependency with a minor bump for security issues. I also updated the parent project and freelib-utils dependencies. Updating the parent project required some more changes:

* Add additional Javadocs that the new Checkstyle rules noticed were missing
* Add the exec-maven-plugin to make the prepare_release scripts executable by default
* Exclude test binary files from the maven-resources-plugin when running with filtering on

Eclipse made a few style changes in the way it breaks lines too.