### PR TITLE
[IIIF-1018] Update packages + location of derivative image delete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1270,7 +1270,7 @@
       <properties>
         <!-- What's the latest version? Cf. https://ubuntuupdates.org/package_metas -->
         <openjdk.version>=11.0.9+11-0ubuntu1~20.04</openjdk.version>
-        <gcc.version>=10-20200411-0ubuntu1</gcc.version>
+        <gcc.version>=4:9.3.0-1ubuntu2</gcc.version>
         <make.version>=4.2.1-1.2</make.version>
         <libtiff.version>=4.1.0+git191117-2build1</libtiff.version>
         <build.essential.version>=12.8ubuntu1.1</build.essential.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1273,7 +1273,7 @@
         <gcc.version>=4:9.3.0-1ubuntu2</gcc.version>
         <make.version>=4.2.1-1.2</make.version>
         <libtiff.version>=4.1.0+git191117-2build1</libtiff.version>
-        <build.essential.version>=12.8ubuntu1.1</build.essential.version>
+        <build.essential.version>=12.8ubuntu1</build.essential.version>
         <libopenjp2.version>=2.3.1-1ubuntu4</libopenjp2.version>
         <git.version>=1:2.25.1-1ubuntu3</git.version>
         <curl.version>=7.68.0-1ubuntu2.2</curl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1268,13 +1268,14 @@
         </property>
       </activation>
       <properties>
-        <openjdk.version>=11.0.8+10-0ubuntu1~20.04</openjdk.version>
-        <gcc.version>=4:9.3.0-1ubuntu2</gcc.version>
+        <!-- What's the latest version? Cf. https://ubuntuupdates.org/package_metas -->
+        <openjdk.version>=11.0.9+11-0ubuntu1~20.04</openjdk.version>
+        <gcc.version>=10-20200411-0ubuntu1</gcc.version>
         <make.version>=4.2.1-1.2</make.version>
         <libtiff.version>=4.1.0+git191117-2build1</libtiff.version>
-        <build.essential.version>=12.8ubuntu1</build.essential.version>
+        <build.essential.version>=12.8ubuntu1.1</build.essential.version>
         <libopenjp2.version>=2.3.1-1ubuntu4</libopenjp2.version>
-        <git.version>=1:2.20.1-2+deb10u3</git.version>
+        <git.version>=1:2.25.1-1ubuntu3</git.version>
         <curl.version>=7.68.0-1ubuntu2.2</curl.version>
         <python2.version>=2.7.17-2ubuntu4</python2.version>
       </properties>

--- a/src/main/java/edu/ucla/library/bucketeer/Constants.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Constants.java
@@ -74,6 +74,11 @@ public final class Constants {
     public static final String JOB_NAME = "job-name";
 
     /**
+     * The header for indicating an image is a derivative image.
+     */
+    public static final String DERIVATIVE_IMAGE = "derivative-image";
+
+    /**
      * The Slack handle of the person submitting the batch job
      */
     public static final String SLACK_HANDLE = "slack-handle";

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -171,7 +171,7 @@
   <entry key="BUCKETEER-159">A URL for the Fester service was not supplied</entry>
   <entry key="BUCKETEER-160">Shutting down test server...</entry>
   <entry key="BUCKETEER-161">Unable to remove temporary image file: {}</entry>
-  <entry key="BUCKETEER-162">Expected to have to delete a temporary image file, but none was found</entry>
+  <entry key="BUCKETEER-162"></entry>
   <entry key="BUCKETEER-163">Working directory does not exist: {}</entry>
   <entry key="BUCKETEER-164">Unable to delete test files from directory: {}</entry>
   <entry key="BUCKETEER-165">Unexpected temporary test files found: {}</entry>


### PR DESCRIPTION
* Update Ubuntu packages for LTS 20.04.1
* Update so that derivative image file deletion happens at the S3BucketVerticle without sending request over the message queue