### PR TITLE
[IIIF-1001] Fix NPE in Item

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/Item.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Item.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Paths;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -165,7 +166,7 @@ public class Item implements Serializable {
         final String filePath;
         final File file;
 
-        if (myFilePath == null || !hasFile() || myFilePath.isEmpty()) {
+        if (!hasFile() || myFilePath.isEmpty()) {
             return Optional.empty();
         } else {
             if (myFilePathPrefix != null) {
@@ -216,8 +217,8 @@ public class Item implements Serializable {
      * @return The item
      */
     public Item setFilePath(final Optional<String> aFilePath) {
+        myFilePath = Objects.requireNonNull(aFilePath);
         myPrefixedFilePath = null;
-        myFilePath = aFilePath;
 
         return this;
     }

--- a/src/main/java/edu/ucla/library/bucketeer/Item.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Item.java
@@ -62,6 +62,9 @@ public class Item implements Serializable {
     @JsonIgnore
     public Item(final String aID, final String aFilePath) {
         myFilePath = Optional.ofNullable(aFilePath);
+        if (myFilePath == null || myFilePath.isEmpty()) {
+            hasImageFile = false;
+        }
         myID = aID;
     }
 
@@ -161,7 +164,9 @@ public class Item implements Serializable {
         final String filePath;
         final File file;
 
-        if (!hasFile() || myFilePath.isEmpty()) {
+        if (myFilePath == null) {
+            return Optional.empty();
+        } else if (!hasFile() || myFilePath.isEmpty()) {
             return Optional.empty();
         } else {
             if (myFilePathPrefix != null) {

--- a/src/main/java/edu/ucla/library/bucketeer/Item.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Item.java
@@ -51,6 +51,7 @@ public class Item implements Serializable {
      */
     public Item() {
         // Used in deserialization and testing
+        myFilePath = Optional.empty();
     }
 
     /**
@@ -62,7 +63,7 @@ public class Item implements Serializable {
     @JsonIgnore
     public Item(final String aID, final String aFilePath) {
         myFilePath = Optional.ofNullable(aFilePath);
-        if (myFilePath == null || myFilePath.isEmpty()) {
+        if (myFilePath.isEmpty()) {
             hasImageFile = false;
         }
         myID = aID;
@@ -164,9 +165,7 @@ public class Item implements Serializable {
         final String filePath;
         final File file;
 
-        if (myFilePath == null) {
-            return Optional.empty();
-        } else if (!hasFile() || myFilePath.isEmpty()) {
+        if (myFilePath == null || !hasFile() || myFilePath.isEmpty()) {
             return Optional.empty();
         } else {
             if (myFilePathPrefix != null) {

--- a/src/test/java/edu/ucla/library/bucketeer/ItemTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/ItemTest.java
@@ -96,6 +96,17 @@ public class ItemTest extends AbstractBucketeerTest {
     }
 
     /**
+     * Tests setting an empty file path.
+     *
+     */
+    @Test
+    public final void testSetEmptyFilePath() {
+        final Item item = new Item(TEST_ID, null);
+
+        assertEquals(Optional.empty(), item.getFilePath());
+    }
+
+    /**
      * Tests getting the item ID.
      */
     @Test

--- a/src/test/java/edu/ucla/library/bucketeer/ItemTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/ItemTest.java
@@ -107,6 +107,17 @@ public class ItemTest extends AbstractBucketeerTest {
     }
 
     /**
+     * Tests setting an empty file path via default constructor.
+     *
+     */
+    @Test
+    public final void testSetEmptyFilePathDefaultConstructor() {
+        final Item item = new Item();
+
+        assertEquals(Optional.empty(), item.getFilePath());
+    }
+
+    /**
      * Tests getting the item ID.
      */
     @Test


### PR DESCRIPTION
A braces-and-belt approach, checking file path at object creation and again in `getFile()`.
Updates:
* Updated `Item.java` to check file path at creation and set `hasImageFile` false when empty; added `if` clause in `getFile()` to double-check file path.
* Added test case to `ItemTest.java` to verify changes to `Item.java`.