### PR TITLE
[IIIF-1103] Clean up Javadoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -527,13 +527,7 @@
           </dependency>
         </dependencies>
         <configuration>
-          <stylesheetfile>javadocs.css</stylesheetfile>
-          <nonavbar>true</nonavbar>
-          <show>public</show>
-          <nosince>true</nosince>
-          <notimestamp>true</notimestamp>
-          <bottom> </bottom>
-          <detectLinks>false</detectLinks>
+          <doclint>all,-syntax</doclint>
           <additionalJOptions>
             <additionalJOption>-J-Dhttp.agent=maven-javadoc-plugin-${project.name}</additionalJOption>
           </additionalJOptions>

--- a/src/main/java/edu/ucla/library/bucketeer/Item.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Item.java
@@ -2,7 +2,6 @@
 package edu.ucla.library.bucketeer;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Paths;
 import java.util.Locale;
@@ -184,7 +183,6 @@ public class Item implements Serializable {
      * Returns the prefixed file name.
      *
      * @return The absolute file path of the item's source file
-     * @throws IOException If there is trouble resolving the path to the file
      */
     @JsonIgnore
     public Optional<String> getPrefixedFilePath() {

--- a/src/main/java/edu/ucla/library/bucketeer/Job.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Job.java
@@ -16,6 +16,7 @@ import com.opencsv.CSVWriter;
 
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -77,7 +78,7 @@ public class Job implements Serializable {
      */
     @JsonIgnore
     public long failedItems() {
-        return myItems.stream().filter(item->item.getWorkflowState().equals(WorkflowState.FAILED)).count();
+        return myItems.stream().filter(item -> item.getWorkflowState().equals(WorkflowState.FAILED)).count();
     }
 
     /**
@@ -87,7 +88,7 @@ public class Job implements Serializable {
      */
     @JsonIgnore
     public long missingItems() {
-        return myItems.stream().filter(item->item.getWorkflowState().equals(WorkflowState.MISSING)).count();
+        return myItems.stream().filter(item -> item.getWorkflowState().equals(WorkflowState.MISSING)).count();
     }
 
     /**
@@ -224,6 +225,7 @@ public class Job implements Serializable {
      * Update the job's metadata with Bucketeer State and IIIF Access URL.
      *
      * @return The job
+     * @throws ProcessingException when there is trouble parsing the metadata
      */
     public Job updateMetadata() throws ProcessingException {
         final List<Item> items = getItems();

--- a/src/main/java/edu/ucla/library/bucketeer/converters/KakaduConverter.java
+++ b/src/main/java/edu/ucla/library/bucketeer/converters/KakaduConverter.java
@@ -92,6 +92,7 @@ public class KakaduConverter extends AbstractConverter implements Converter {
      *
      * @param aFile An image file
      * @return The path of the supplied image file
+     * @throws IOException If the file doesn't exist and can't be written
      */
     public String getPath(final File aFile) throws IOException {
         if (!aFile.exists() && !aFile.getParentFile().canWrite()) {


### PR DESCRIPTION
Running the Javadocs in the GitHub Actions complained about some syntax issues with the Javadoc generation (which failed the publishing of the Docker image). I've specified specific rules in the javadoc-maven-plugin configuration now and cleaned up some Javadoc issues that were pointed out with the new rules.