### PR TITLE
[IIIF-1108] Update S3Client configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <openjdk.version>11.0.10+9-0ubuntu1~20.04</openjdk.version>
     <gcc.version>4:9.3.0-1ubuntu2</gcc.version>
     <make.version>4.2.1-1.2</make.version>
-    <libtiff.version>4.1.0+git191117-2build1</libtiff.version>
+    <libtiff.version>4.1.0+git191117-2ubuntu0.20.04.1</libtiff.version>
     <build.essential.version>12.8ubuntu1.1</build.essential.version>
     <libopenjp2.version>2.3.1-1ubuntu4.20.04.1</libopenjp2.version>
     <curl.version>7.68.0-1ubuntu2.4</curl.version>

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
@@ -68,7 +68,7 @@ public class S3BucketVerticle extends AbstractBucketeerVerticle {
             final HttpClientOptions options = new HttpClientOptions();
 
             // Set the S3 client options
-            options.setDefaultHost(s3Region);
+            options.setSsl(true).setDefaultPort(443).setDefaultHost(s3Region);
 
             myS3Client = new S3Client(getVertx(), s3AccessKey, s3SecretKey, options);
 


### PR DESCRIPTION
Update of the underlying S3 library broke our S3 configuration. It assumed if one supplied HttpClientOptions that they were supplying both host and port. We only supplied host (and didn't mark it as HTTPS). This should fix our config in Bucketeer.