### PR TITLE
Update notifications sent via Slack

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
@@ -222,7 +222,8 @@ public class S3BucketVerticle extends AbstractBucketeerVerticle {
                 if (retryCheck.result()) {
                     sendReply(aMessage, 0, Op.RETRY);
                 } else {
-                    sendReply(aMessage, CodeUtils.getInt(MessageCodes.BUCKETEER_140), String.valueOf(myMaxRetries));
+                    final String message = LOGGER.getMessage(MessageCodes.BUCKETEER_140, myMaxRetries, aImageID);
+                    sendReply(aMessage, CodeUtils.getInt(MessageCodes.BUCKETEER_000), message);
                 }
             } else {
                 final Throwable retryException = retryCheck.cause();

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -150,7 +150,7 @@
   <entry key="BUCKETEER-137">Failed to remove job from queue: {}</entry>
   <entry key="BUCKETEER-138">Failed to increment S3 upload counter</entry>
   <entry key="BUCKETEER-139">Failed to get S3 upload counter</entry>
-  <entry key="BUCKETEER-140">Stopped retrying S3 upload; maximum number of retries allowed reached: {}</entry>
+  <entry key="BUCKETEER-140">Stopped retrying S3 upload; maximum number of retries allowed reached: {} [{}]</entry>
   <entry key="BUCKETEER-141">Successfully marked item '{}' as failed</entry>
   <entry key="BUCKETEER-142">Refused to delete '{}' job because it's still processing images</entry>
   <entry key="BUCKETEER-143">Test server for {} started...</entry>
@@ -200,4 +200,5 @@
   <entry key="BUCKETEER-519">The CSV '{}' is available on the mounted filesystem.</entry>
   <entry key="BUCKETEER-520">The CSV '{}' could not be written to the mounted filesystem: {}.</entry>
   <entry key="BUCKETEER-521">There are spaces (" ") in one or more "File Name" entries in CSV {} for job {}</entry>
+  <entry key="BUCKETEER-522">Bucketeer was not able to send a message through Slack so the CSV was not delivered</entry>
 </properties>

--- a/src/test/scripts/fake-lambda.sh
+++ b/src/test/scripts/fake-lambda.sh
@@ -9,6 +9,11 @@
 #
 # This is only for development purposes and thus assumes you are running at http://localhost:8888
 #
+# This pattern can also be used to clear Bucketeer jobs that are stuck on a real server; for that, type the full URL:
+#   curl -X PATCH "https://bucketeer.library.ucla.edu/batch/jobs/minasian-pages-3/ark%3A%2F21198%2Fzz002gp8t4/true"
+#
+# The quotation marks around the URL are important.
+#
 
 if [ -z "$1" ]; then
   echo "Please include a job name when you run this script:"


### PR DESCRIPTION
* Stop notifying the error channel of updates on killed jobs
* Better log when we cannot send the CSV output through Slack
* Let the newer version of Eclipse do some code format updating
* Add some more documentation in the fake-lambda script