### PR TITLE
[SERV-326] Fix batch job status update bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,35 +79,35 @@
 
     <!-- OS pinned package versions (Cf. https://ubuntuupdates.org/package_metas for latest versions) -->
     <ubuntu.tag>20.04</ubuntu.tag>
-    <openjdk.version>11.0.11+9-0ubuntu2~20.04</openjdk.version>
+    <openjdk.version>11.0.13+8-0ubuntu1~20.04</openjdk.version>
     <gcc.version>4:9.3.0-1ubuntu2</gcc.version>
     <make.version>4.2.1-1.2</make.version>
-    <libtiff.version>4.1.0+git191117-2ubuntu0.20.04.1</libtiff.version>
+    <libtiff.version>4.1.0+git191117-2ubuntu0.20.04.2</libtiff.version>
     <build.essential.version>12.8ubuntu1.1</build.essential.version>
     <libopenjp2.version>2.3.1-1ubuntu4.20.04.1</libopenjp2.version>
-    <curl.version>7.68.0-1ubuntu2.6</curl.version>
+    <curl.version>7.68.0-1ubuntu2.7</curl.version>
     <python2.version>2.7.17-2ubuntu4</python2.version>
 
     <!-- Application dependencies -->
-    <vertx.version>3.9.7</vertx.version>
+    <vertx.version>3.9.12</vertx.version>
     <vertx.super.s3.version>1.3.3</vertx.super.s3.version>
-    <slf4j.ext.version>1.7.26</slf4j.ext.version>
-    <aws.sdk.version>1.11.1017</aws.sdk.version>
+    <slf4j.ext.version>1.7.32</slf4j.ext.version>
+    <aws.sdk.version>1.12.139</aws.sdk.version>
     <commons.codec.version>1.14</commons.codec.version>
     <aws.v4.signer.version>1.3</aws.v4.signer.version>
     <opencsv.version>4.6</opencsv.version>
-    <moirai.version>2.0.0</moirai.version>
+    <moirai.version>2.1.0</moirai.version>
     <beanutils.version>1.9.4</beanutils.version>
     <woodstox.version>5.1.0</woodstox.version>
-    <freelib.utils.version>2.1.0</freelib.utils.version>
-    <freelib.maven.version>0.1.2</freelib.maven.version>
-    <netty.epoll.version>4.1.37.Final</netty.epoll.version>
+    <freelib.utils.version>3.0.1</freelib.utils.version>
+    <freelib.maven.version>0.3.0</freelib.maven.version>
+    <netty.epoll.version>4.1.73.Final</netty.epoll.version>
     <maven.failsafe.plugin.version>2.18.1</maven.failsafe.plugin.version>
     <jslack.version>1.7.8</jslack.version>
-    <snakeyaml.version>1.26</snakeyaml.version>
+    <snakeyaml.version>1.30</snakeyaml.version>
     <oshi.version>4.0.0</oshi.version>
-    <jackson.version>2.12.1</jackson.version>
-    <jsoup.version>1.13.1</jsoup.version>
+    <jackson.version>2.13.1</jackson.version>
+    <jsoup.version>1.14.3</jsoup.version>
 
     <!-- Build plug-in versions -->
     <scm.plugin.version>1.11.2</scm.plugin.version>
@@ -672,7 +672,9 @@
                   <exclude>io.netty:netty-handler</exclude>
                   <exclude>io.netty:netty-resolver-dns</exclude>
                   <exclude>io.netty:netty-resolver</exclude>
+                  <exclude>io.netty:netty-tcnative-classes</exclude>
                   <exclude>io.netty:netty-transport</exclude>
+                  <exclude>io.netty:netty-transport-classes-epoll</exclude>
                   <exclude>io.netty:netty-transport-native-epoll</exclude>
                   <exclude>io.netty:netty-transport-native-unix-common</exclude>
                   <exclude>io.swagger.core.v3:swagger-annotations</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -895,6 +895,7 @@
                 <configuration>
                   <checkoutDirectory>${basedir}/src/main/docker/kakadu</checkoutDirectory>
                   <connectionUrl>${kakadu.git.repo}</connectionUrl>
+                  <scmVersion>main</scmVersion>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -895,6 +895,7 @@
                 <configuration>
                   <checkoutDirectory>${basedir}/src/main/docker/kakadu</checkoutDirectory>
                   <connectionUrl>${kakadu.git.repo}</connectionUrl>
+                  <scmVersionType>branch</scmVersionType>
                   <scmVersion>main</scmVersion>
                 </configuration>
               </execution>

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/BatchJobStatusHandler.java
@@ -192,13 +192,9 @@ public class BatchJobStatusHandler extends AbstractBucketeerHandler {
 
                     // We send the name of the job to finalize to the appropriate verticle
                     sendMessage(myVertx, message, FinalizeJobVerticle.class.getName());
-
-                    // Let the submitter know we're done
-                    returnSuccess(response, LOGGER.getMessage(MessageCodes.BUCKETEER_081, job.getName()));
-                } else {
-                    // If not finished, return an acknowledgement to the image processor
-                    returnSuccess(response, LOGGER.getMessage(MessageCodes.BUCKETEER_081, job.getName()));
                 }
+                // Let the submitter know we're done
+                returnSuccess(response, LOGGER.getMessage(MessageCodes.BUCKETEER_081, job.getName()));
             } else {
                 aLock.release();
                 returnError(getJob.cause(), MessageCodes.BUCKETEER_076, jobName, response);

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/GetJobStatusesHandler.java
@@ -12,6 +12,7 @@ import edu.ucla.library.bucketeer.HTTP;
 import edu.ucla.library.bucketeer.Item;
 import edu.ucla.library.bucketeer.Job;
 import edu.ucla.library.bucketeer.MessageCodes;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;

--- a/src/main/java/edu/ucla/library/bucketeer/handlers/MatchingOpNotFoundHandler.java
+++ b/src/main/java/edu/ucla/library/bucketeer/handlers/MatchingOpNotFoundHandler.java
@@ -47,25 +47,23 @@ public class MatchingOpNotFoundHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(final RoutingContext aContext) {
-        if (aContext.failed()) {
-            final HttpServerRequest request = aContext.request();
-            final String method = request.rawMethod();
-            final String path = request.path();
+        final HttpServerRequest request = aContext.request();
+        final String method = request.rawMethod();
+        final String path = request.path();
 
-            if (path.matches(STATUS_UPDATE_RE)) { // Check batch job status updates
-                if (!HttpMethod.PATCH.name().equals(method)) {
-                    error(aContext, HTTP.METHOD_NOT_ALLOWED, LOGGER.getMessage(MessageCodes.BUCKETEER_034, method));
-                } else if (path.matches(MISSING_ID_RE)) {
-                    error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_600));
-                } else if (path.matches(MISSING_JOB_RE)) {
-                    error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_601));
-                }
-            } else if (path.matches(MISSING_STATUS_RE)) { // Check that updates without a status are caught
-                error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_602));
-            } else if (HttpMethod.PATCH.name().equals(method)) { // Handle other random PATCH API requests
-                error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_162, path));
+        if (path.matches(STATUS_UPDATE_RE)) { // Check batch job status updates
+            if (!HttpMethod.PATCH.name().equals(method)) {
+                error(aContext, HTTP.METHOD_NOT_ALLOWED, LOGGER.getMessage(MessageCodes.BUCKETEER_034, method));
+            } else if (path.matches(MISSING_ID_RE)) {
+                error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_600));
+            } else if (path.matches(MISSING_JOB_RE)) {
+                error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_601));
             }
-        } // Ignore successful contexts, their responses have been returned
+        } else if (path.matches(MISSING_STATUS_RE)) { // Check that updates without a status are caught
+            error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_602));
+        } else if (HttpMethod.PATCH.name().equals(method)) { // Handle other random PATCH API requests
+            error(aContext, HTTP.BAD_REQUEST, LOGGER.getMessage(MessageCodes.BUCKETEER_162, path));
+        }
     }
 
     /**

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -42,7 +42,7 @@
   <entry key="BUCKETEER-031">Failed to deploy main verticle for testing</entry>
   <entry key="BUCKETEER-032">No known converter</entry>
   <entry key="BUCKETEER-033">Using test image for kakadu conversion: {}</entry>
-  <entry key="BUCKETEER-034">Only the PATCH method is supported for status updates; received: {}</entry>
+  <entry key="BUCKETEER-034">Bad Request: Only the PATCH method is supported for status updates; received: {}</entry>
   <entry key="BUCKETEER-035">Couldn't optimize for Linux performance; running on: {}|{}</entry>
   <entry key="BUCKETEER-036">Sending test image upload request: {}</entry>
   <entry key="BUCKETEER-037">Checking for JP2, attempt number: {}</entry>
@@ -172,7 +172,7 @@
   <entry key="BUCKETEER-159">A URL for the Fester service was not supplied</entry>
   <entry key="BUCKETEER-160">Shutting down test server...</entry>
   <entry key="BUCKETEER-161">Unable to remove temporary image file: {}</entry>
-  <entry key="BUCKETEER-162"></entry>
+  <entry key="BUCKETEER-162">Unexpected request to nonexistent API endpoint: {}</entry>
   <entry key="BUCKETEER-163">Working directory does not exist: {}</entry>
   <entry key="BUCKETEER-164">Unable to delete test files from directory: {}</entry>
   <entry key="BUCKETEER-165">Unexpected temporary test files found: {}</entry>
@@ -201,4 +201,7 @@
   <entry key="BUCKETEER-520">The CSV '{}' could not be written to the mounted filesystem: {}.</entry>
   <entry key="BUCKETEER-521">There are spaces (" ") in one or more "File Name" entries in CSV {} for job {}</entry>
   <entry key="BUCKETEER-522">Bucketeer was not able to send a message through Slack so the CSV was not delivered</entry>
+  <entry key="BUCKETEER-600">Bad Request: No item ID supplied</entry>
+  <entry key="BUCKETEER-601">Bad Request: No job name supplied</entry>
+  <entry key="BUCKETEER-602">Bad Request: Status update must be 'true' or 'false'</entry>
 </properties>


### PR DESCRIPTION
* Update app and container dependencies (for security fixes)
* Add two new ignores/excludes to the warnings the Jar process spits out
* Include Eclipse syntax fixes to BatchJobStatusHandler and GetJobStatusesHandler
* Fix MatchingOpNotFoundHandler so it handles edge cases better (i.e., the bug)
* Add tests for MatchingOpNotFoundHandler's improved edge case handling

This PR aims to fix the bug where Bucketeer won't respond to an endpoint request when the request it receives isn't complete.

Not getting a success or failure response, our AWS Lambda (the requestor) keeps waiting until it times out. This causes it to unnecessarily run up a charge on AWS.