### PR TITLE
[DLSR-102] Add Width/Height Metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <vertx.plugin.version>1.0.18</vertx.plugin.version>
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>
-    <docker.maven.plugin.version>0.38.1</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.48.1</docker.maven.plugin.version>
     <maven.download.plugin.version>1.3.0</maven.download.plugin.version>
 
     <!-- These properties provide the ability to override the running of any type of test -->

--- a/src/main/java/edu/ucla/library/bucketeer/Item.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Item.java
@@ -8,9 +8,11 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 import info.freelibrary.util.StringUtils;
 
@@ -22,7 +24,8 @@ import io.vertx.core.json.JsonObject;
 /**
  * A batch job item.
  */
-@JsonPropertyOrder({ "id", "filePath", "accessURL", "workflowState", "filePathPrefix" })
+@JsonPropertyOrder({ "id", "filePath", "accessURL", "workflowState", "filePathPrefix", Metadata.MEDIA_WIDTH,
+    Metadata.MEDIA_HEIGHT })
 public class Item implements Serializable {
 
     /** The <code>serialVersionUID</code> of the Item. */
@@ -39,6 +42,12 @@ public class Item implements Serializable {
 
     /** The item's image access URL. */
     private String myAccessURL;
+
+    /** The item's image width. */
+    private String myWidth;
+
+    /** The item's image height. */
+    private String myHeight;
 
     /** A flag indicating whether the item has an image file associated with it. */
     private boolean hasImageFile = true;
@@ -225,6 +234,48 @@ public class Item implements Serializable {
         myFilePath = Objects.requireNonNull(aFilePath);
         myPrefixedFilePath = null;
 
+        return this;
+    }
+
+    /**
+     * Gets the item's image width.
+     *
+     * @return The item's image width
+     */
+    @JsonGetter(Metadata.MEDIA_WIDTH)
+    public Optional<String> getWidth() {
+        return Optional.ofNullable(myWidth);
+    }
+
+    /**
+     * Gets the item's image height.
+     *
+     * @return The item's image height
+     */
+    @JsonGetter(Metadata.MEDIA_HEIGHT)
+    public Optional<String> getHeight() {
+        return Optional.ofNullable(myHeight);
+    }
+
+    /**
+     * Sets the item's image width.
+     *
+     * @param aWidth The item's image width
+     */
+    @JsonSetter(Metadata.MEDIA_WIDTH)
+    public Item setWidth(final int aWidth) {
+        myWidth = Integer.toString(aWidth);
+        return this;
+    }
+
+    /**
+     * Sets the item's image height.
+     *
+     * @param aHeight The item's image height
+     */
+    @JsonSetter(Metadata.MEDIA_HEIGHT)
+    public Item setHeight(final int aHeight) {
+        myHeight = Integer.toString(aHeight);
         return this;
     }
 

--- a/src/main/java/edu/ucla/library/bucketeer/Job.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Job.java
@@ -4,6 +4,7 @@ package edu.ucla.library.bucketeer;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -234,57 +235,45 @@ public class Job implements Serializable {
      */
     @SuppressWarnings("PMD.CyclomaticComplexity")
     public Job updateMetadata() throws ProcessingException {
+        final List<String> missingHeaders = new ArrayList<>();
         final List<Item> items = getItems();
 
-        final String[] newHeader;
-        final String[] additionalHeaders;
-
-        final int newHeaderLength;
-        final int additionalHeadersCount;
-
-        // Find the index position of our two columns: Bucketeer State and Access URL
         int bucketeerStateIndex = findHeader(Metadata.BUCKETEER_STATE);
         int accessUrlIndex = findHeader(Metadata.IIIF_ACCESS_URL);
+        int widthIndex = findHeader(Metadata.MEDIA_WIDTH);
+        int heightIndex = findHeader(Metadata.MEDIA_HEIGHT);
 
-        // Check which headers already exist in the metadata
-        final boolean bucketeerStateMissing = bucketeerStateIndex == -1;
-        final boolean accessUrlMissing = accessUrlIndex == -1;
+        int nextIndex = myMetadataHeader.length;
 
-        // If both headers are missing, we need to expand our headers array by two
-        if (bucketeerStateMissing && accessUrlMissing) {
-            additionalHeadersCount = 2;
-            additionalHeaders = new String[additionalHeadersCount];
-            additionalHeaders[0] = Metadata.BUCKETEER_STATE;
-            additionalHeaders[1] = Metadata.IIIF_ACCESS_URL;
-
-            bucketeerStateIndex = myMetadataHeader.length;
-            accessUrlIndex = myMetadataHeader.length + 1;
-        } else if (bucketeerStateMissing) {
-            // If only one header is missing, we need to expand our headers array by one
-            additionalHeadersCount = 1;
-            additionalHeaders = new String[additionalHeadersCount];
-            additionalHeaders[0] = Metadata.BUCKETEER_STATE;
-
-            bucketeerStateIndex = myMetadataHeader.length;
-        } else if (accessUrlMissing) {
-            // Expand by one
-            additionalHeadersCount = 1;
-            additionalHeaders = new String[additionalHeadersCount];
-            additionalHeaders[0] = Metadata.IIIF_ACCESS_URL;
-
-            accessUrlIndex = myMetadataHeader.length;
-        } else {
-            // No change
-            additionalHeadersCount = 0;
-            additionalHeaders = new String[additionalHeadersCount];
+        if (bucketeerStateIndex == -1) {
+            bucketeerStateIndex = nextIndex++;
+            missingHeaders.add(Metadata.BUCKETEER_STATE);
         }
 
-        LOGGER.debug(MessageCodes.BUCKETEER_155, additionalHeadersCount);
-        newHeaderLength = myMetadataHeader.length + additionalHeadersCount;
+        if (accessUrlIndex == -1) {
+            accessUrlIndex = nextIndex++;
+            missingHeaders.add(Metadata.IIIF_ACCESS_URL);
+        }
 
-        // Update the headers if there are changes
-        if (bucketeerStateMissing || accessUrlMissing) {
-            newHeader = new String[newHeaderLength];
+        if (widthIndex == -1) {
+            widthIndex = nextIndex++;
+            missingHeaders.add(Metadata.MEDIA_WIDTH);
+        }
+
+        if (heightIndex == -1) {
+            heightIndex = nextIndex++;
+            missingHeaders.add(Metadata.MEDIA_HEIGHT);
+        }
+
+        final int additionalHeadersCount = missingHeaders.size();
+        final boolean headersChanged = additionalHeadersCount > 0;
+        final int newHeaderLength = myMetadataHeader.length + additionalHeadersCount;
+
+        LOGGER.debug(MessageCodes.BUCKETEER_155, additionalHeadersCount);
+
+        if (headersChanged) {
+            final String[] additionalHeaders = missingHeaders.toArray(new String[0]);
+            final String[] newHeader = new String[newHeaderLength];
 
             System.arraycopy(myMetadataHeader, 0, newHeader, 0, myMetadataHeader.length);
             System.arraycopy(additionalHeaders, 0, newHeader, myMetadataHeader.length, additionalHeadersCount);
@@ -292,28 +281,31 @@ public class Job implements Serializable {
             setMetadataHeader(newHeader);
         }
 
-        // Then let's loop through the metadata and add or update columns as needed
         for (int index = 0; index < myMetadata.size(); index++) {
             final Item item = items.get(index);
 
             String[] row = myMetadata.get(index);
 
-            // If the number of columns has changed, increase our metadata row array size
-            if (bucketeerStateMissing || accessUrlMissing) {
+            if (headersChanged) {
                 final String[] newRow = new String[newHeaderLength];
 
                 System.arraycopy(row, 0, newRow, 0, row.length);
                 row = newRow;
             }
 
-            // We mark structural rows with empty statuses before outputting the CSV data
-            if (WorkflowState.STRUCTURAL.equals(item.getWorkflowState())) {
-                row[bucketeerStateIndex] = WorkflowState.EMPTY.toString();
-            } else {
-                row[bucketeerStateIndex] = item.getWorkflowState().toString();
-            }
+            row[bucketeerStateIndex] = WorkflowState.STRUCTURAL.equals(item.getWorkflowState())
+                    ? WorkflowState.EMPTY.toString() : item.getWorkflowState().toString();
 
             row[accessUrlIndex] = item.getAccessURL();
+
+            if (item.getWidth().isPresent()) {
+                row[widthIndex] = item.getWidth().get();
+            }
+
+            if (item.getHeight().isPresent()) {
+                row[heightIndex] = item.getHeight().get();
+            }
+
             myMetadata.set(index, row);
         }
 

--- a/src/main/java/edu/ucla/library/bucketeer/Metadata.java
+++ b/src/main/java/edu/ucla/library/bucketeer/Metadata.java
@@ -49,8 +49,21 @@ public final class Metadata {
      */
     public static final String WORK = "Work";
 
-    // Constants classes should not have public constructors.
+    /**
+     * The item's image width.
+     */
+    public static final String MEDIA_WIDTH = "media.width";
+
+    /**
+     * The item's image height.
+     */
+    public static final String MEDIA_HEIGHT = "media.height";
+
+    /**
+     * Constants classes should not have public constructors.
+     */
     private Metadata() {
+        // This is intentionally left empty
     }
 
 }

--- a/src/test/java/edu/ucla/library/bucketeer/JobTest.java
+++ b/src/test/java/edu/ucla/library/bucketeer/JobTest.java
@@ -11,8 +11,9 @@ import java.util.List;
 
 import org.junit.Test;
 
-import edu.ucla.library.bucketeer.Job.WorkflowState;
 import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.bucketeer.Job.WorkflowState;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -147,7 +148,7 @@ public class JobTest extends AbstractBucketeerTest {
         newMetadata = job.getMetadata();
 
         // IIIF Access URL should have been added
-        assertEquals(originalHeader.length + 1, newHeader.length);
+        assertEquals(originalHeader.length + 3, newHeader.length);
         assertTrue(newHeader[originalHeader.length].equals(Metadata.IIIF_ACCESS_URL));
 
         // Bucketeer State of all items should be predictable
@@ -159,6 +160,7 @@ public class JobTest extends AbstractBucketeerTest {
             } else {
                 expectedWorkflowState = WorkflowState.EMPTY;
             }
+
             assertTrue(row[bucketeerStateIndex].equals(expectedWorkflowState.toString()));
         }
     }

--- a/src/test/resources/json/generic-item.json
+++ b/src/test/resources/json/generic-item.json
@@ -5,5 +5,7 @@
     "workflowState": "",
     "filePathPrefix": {
         "genericRootDir": "."
-    }
+    },
+    "media.width": null,
+    "media.height": null
 }

--- a/src/test/resources/json/item.json
+++ b/src/test/resources/json/item.json
@@ -5,5 +5,7 @@
     "workflowState": "failed",
     "filePathPrefix": {
         "genericRootDir": "."
-    }
+    },
+    "media.width": null,
+    "media.height": null
 }

--- a/src/test/resources/json/job.json
+++ b/src/test/resources/json/job.json
@@ -10,7 +10,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb009n998t",
@@ -19,7 +21,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb038nb0bm",
@@ -28,7 +32,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb0489n655",
@@ -37,7 +43,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb058002j1",
@@ -46,7 +54,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb058002kj",
@@ -55,7 +65,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb0779n6bd",
@@ -64,7 +76,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb0779n6cx",
@@ -73,7 +87,9 @@
             "workflowState": "failed",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         },
         {
             "id": "ark:/13030/hb08700381",
@@ -82,7 +98,9 @@
             "workflowState": "",
             "filePathPrefix": {
                 "genericRootDir": "."
-            }
+            },
+            "media.width": null,
+            "media.height": null
         }
     ],
     "metadataHeader": [

--- a/src/test/resources/json/ucla-item.json
+++ b/src/test/resources/json/ucla-item.json
@@ -5,5 +5,7 @@
     "workflowState": "",
     "filePathPrefix": {
         "uclaRootDir": "/tmp"
-    }
+    },
+    "media.width": null,
+    "media.height": null
 }


### PR DESCRIPTION
Trying to take this in smaller bites to make the PR(s) easier to review.

In this PR, I add the width/height properties in the Job/Item Metadata. Right now, no width/height is set so all the pre-existing tests should (still) pass, except those that check the JSON serialization of Item.

For those, I modified their expected JSON to have the new properties with `null` values (which is okay, because this is not human facing and we already have other values that may also have null in the JSON serialization).

The next PR will include a WidthHeightVerticle that extracts width and height from the source image and updates the Job's Item.

Details:
* Bump Docker Maven Plugin version
* Add additional media.width and media.height metadata
* Refactor the process of updating Job/Item metadata
* Update test expectations