### PR TITLE
[DLSR-464] Ignore non-width/height metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.BUILD_PASSPHRASE }}
           MAVEN_GPG_KEY: ${{ secrets.BUILD_KEY }}
         run: |
-          mvn -V -B deploy -Dmaven.javadoc.skip=true -DskipPublishing=true \
+          mvn -V -B deploy -Dmaven.javadoc.skip=true -DskipPublishing=true -DlogLevel="INFO" \
           -Prelease -Drevision=${{ github.event.release.tag_name }} \
           -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error \
           -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }} \

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/WidthHeightVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/WidthHeightVerticle.java
@@ -48,7 +48,7 @@ public class WidthHeightVerticle extends AbstractBucketeerVerticle {
                 reader = readers.next();
 
                 try {
-                    reader.setInput(inStream);
+                    reader.setInput(inStream, false, true);
                     reply = new JsonObject().put(Constants.WIDTH, Integer.toString(reader.getWidth(0)))
                             .put(Constants.HEIGHT, Integer.toString(reader.getHeight(0)));
 

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -214,7 +214,7 @@
   <entry key="BUCKETEER-609">Username or password is not valid; Username: '{}'</entry>
   <entry key="BUCKETEER-610">Cantaloupe cache was not properly cleared; image remained the same after attempt of clearing</entry>
   <entry key="BUCKETEER-611">Unexpected Cantaloupe response: {} [{}]</entry>
-  <entry key="BUCKETEER-612">Failed to find an image from which to extract width/height: {} [{}]</entry>
+  <entry key="BUCKETEER-612">Failed to extract width/height: {} [{}]</entry>
   <entry key="BUCKETEER-613">No ImageReader available for TIFF: {}</entry>
   <entry key="BUCKETEER-614">Timed out waiting for CSV file: {}</entry>
   <entry key="BUCKETEER-615">Could not open image input stream for: {}</entry>


### PR DESCRIPTION
Ignore the other metadata when reading image width and height.

Also:
* Adjust logging level in release configuration
* Improve accuracy of logging message